### PR TITLE
Remove remount-readonly feature from partition (non-LV)  backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ This example demonstrates **four backup destinations** per volume using a combin
 [standard_path.boot-efi]
 backup_source_path = "/boot/efi"
 exclude_paths = []
-remount_readonly = false
 
   [[standard_path.boot-efi.repositories]]
   repo_path = "/path/to/boot-efi-repo"
@@ -134,7 +133,6 @@ remount_readonly = false
 [standard_path.boot]
 backup_source_path = "/boot"
 exclude_paths = []
-remount_readonly = false
 
   [[standard_path.boot.repositories]]
   repo_path = "/path/to/boot-repo"
@@ -310,8 +308,6 @@ backup_source_path = "/path/to/source"
 - **`[[<volume_type>.<volume_id>.repositories.copy_to]]`** — Copy destination (can have multiple per repository)
   - Copies snapshots from the parent repository after backup completes
 
-**⚠️ CRITICAL WARNING:** If backing up a standard partition mounted at `/` using `standard_path`, you **MUST** set `remount_readonly = false`. Attempting to remount the root filesystem read-only will cause system instability or failure.
-
 
 ### Running Specific Jobs from Config File
 
@@ -381,7 +377,6 @@ See [Restic documentation](https://restic.readthedocs.io/en/stable/030_preparing
 
 - **`snapshot_size`** must be large enough to capture changes during backup. Overflow causes backup failure.
 - **`exclude_paths`** is a TOML array of paths to exclude from backup.
-- **`remount_readonly`** (standard_path only) temporarily remounts the source read-only during backup.
 - **Multiple repos per job** — All `[[repositories]]` receive the same snapshot data.
 - **`copy_to` destinations** — Receive copies after local backup completes.
 - **All repositories must exist** — Use `restic init` to create each repo before first use.

--- a/src/resticlvm/orchestration/dispatch.py
+++ b/src/resticlvm/orchestration/dispatch.py
@@ -10,7 +10,6 @@ STANDARD_PATH_TOKEN_KEY_MAP = {
     "-p": "restic_password_file",
     "-s": "backup_source_path",
     "-e": "exclude_paths",
-    "-m": "remount_readonly",
 }
 
 # Mapping of CLI tokens to configuration keys for logical volume backups.

--- a/src/resticlvm/scripts/backup_path.sh
+++ b/src/resticlvm/scripts/backup_path.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
 # Backup a standard filesystem path using Restic.
-# Optionally remounts the source path as read-only during the backup.
 #
 # Arguments:
 #   -r  Path to the Restic repository.
 #   -p  Path to the Restic password file.
 #   -s  Path to the backup source directory.
 #   -e  (Optional) Comma-separated list of paths to exclude.
-#   -m  (Optional) Remount the backup source as read-only during backup (true/false).
 #   --dry-run  (Optional) Show actions without executing them.
 #
 # Usage:
@@ -35,11 +33,10 @@ BACKUP_SOURCE_PATH=""
 RESTIC_REPOS=()
 RESTIC_PASSWORD_FILES=()
 EXCLUDE_PATHS=""
-REMOUNT_AS_RO="false"
 DRY_RUN=false
 
 # ─── Parse and Validate Arguments ─────────────────────────────────
-parse_arguments usage_path "restic-repo password-file backup-source exclude-paths remount-as-ro dry-run" "$@"
+parse_arguments usage_path "restic-repo password-file backup-source exclude-paths dry-run" "$@"
 
 # Validate basic args
 validate_args usage_path_backup BACKUP_SOURCE_PATH
@@ -60,7 +57,7 @@ check_if_path_exists "$BACKUP_SOURCE_PATH"
 
 # ─── Display Configuration ───────────────────────────────────────
 display_config "Backup Configuration" \
-    BACKUP_SOURCE_PATH EXCLUDE_PATHS REMOUNT_AS_RO DRY_RUN
+    BACKUP_SOURCE_PATH EXCLUDE_PATHS DRY_RUN
 
 echo "Repositories: ${#RESTIC_REPOS[@]}"
 for i in "${!RESTIC_REPOS[@]}"; do
@@ -68,11 +65,6 @@ for i in "${!RESTIC_REPOS[@]}"; do
 done
 
 display_dry_run_message "$DRY_RUN"
-
-# ─── Remount Read-Only if Needed ──────────────────────────────────
-if [ "$REMOUNT_AS_RO" = true ]; then
-    remount_as_read_only "$DRY_RUN" "$BACKUP_SOURCE_PATH"
-fi
 
 # ─── Build Exclude Arguments (Once) ───────────────────────────────
 EXCLUDE_ARGS=()
@@ -101,11 +93,6 @@ for i in "${!RESTIC_REPOS[@]}"; do
     # Execute backup for this repo
     run_or_echo "$DRY_RUN" "$RESTIC_CMD"
 done
-
-# ─── Remount Back to Read-Write if Needed ─────────────────────────
-if [ "$REMOUNT_AS_RO" = true ]; then
-    remount_as_read_write "$DRY_RUN" "$BACKUP_SOURCE_PATH"
-fi
 
 # ─── Done ─────────────────────────────────────────────────────────
 echo ""

--- a/src/resticlvm/scripts/lib/arg_handlers.sh
+++ b/src/resticlvm/scripts/lib/arg_handlers.sh
@@ -65,15 +65,6 @@ parse_arguments() {
             EXCLUDE_PATHS="$2"
             shift 2
             ;;
-        -m | --remount-as-ro)
-            if [[ "$allowed_flags" == *"remount-as-ro"* ]]; then
-                REMOUNT_AS_RO="$2"
-                shift 2
-            else
-                echo "❌ Unexpected option: $1"
-                "$usage_function"
-            fi
-            ;;
         -n | --dry-run)
             DRY_RUN=true
             shift

--- a/src/resticlvm/scripts/lib/usage_commands.sh
+++ b/src/resticlvm/scripts/lib/usage_commands.sh
@@ -11,14 +11,13 @@
 
 usage_path() {
     echo "Usage:"
-    echo "$0 -r REPO -p PASSFILE -s SRC [-e EXCLUDES] [-m] [-n]"
+    echo "$0 -r REPO -p PASSFILE -s SRC [-e EXCLUDES] [-n]"
     echo ""
     echo "Options:"
     echo "  -r, --restic-repo      Restic repository path"
     echo "  -p, --password-file    Path to password file"
     echo "  -s, --backup-source    Path to back up"
     echo "  -e, --exclude-paths    Space-separated paths to exclude"
-    echo "  -m, --remount-as-ro   Remount source as read-only (default: false)"
     echo "  -n, --dry-run          Dry run mode (preview only)"
     echo "  -h, --help             Display this message and exit"
     exit 1

--- a/test/test_backup_plan.py
+++ b/test/test_backup_plan.py
@@ -32,7 +32,6 @@ backup_source_path = "/boot"
 restic_repo = "/srv/backup/boot"
 restic_password_file = "/tmp/password.txt"
 exclude_paths = []
-remount_readonly = true
 prune_keep_last = 5
 prune_keep_daily = 7
 prune_keep_weekly = 4
@@ -90,7 +89,7 @@ def test_backup_plan_create_backup_job_standard_path(temp_config_file):
     assert job.name == "boot"
     assert job.script_name == "backup_path.sh"
     assert job.config["backup_source_path"] == "/boot"
-    assert job.config["remount_readonly"] is True
+
 
 
 def test_backup_plan_create_backup_job_invalid_category(temp_config_file):
@@ -140,7 +139,7 @@ backup_source_path = "/home"
 restic_repo = "/backup/home"
 restic_password_file = "/tmp/pass.txt"
 exclude_paths = [".cache"]
-remount_readonly = false
+
 prune_keep_last = 3
 prune_keep_daily = 7
 prune_keep_weekly = 4

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -74,7 +74,7 @@ backup_source_path = "/boot"
 restic_repo = "/backup/boot"
 restic_password_file = "/tmp/pass.txt"
 exclude_paths = []
-remount_readonly = true
+
 prune_keep_last = 5
 prune_keep_daily = 7
 prune_keep_weekly = 4

--- a/test/test_data_classes.py
+++ b/test/test_data_classes.py
@@ -104,24 +104,6 @@ def test_backup_job_get_arg_entry_list():
     assert arg_entry == ["-e", "/dev /proc /sys"]
 
 
-def test_backup_job_get_arg_entry_bool():
-    """Test get_arg_entry with a boolean value."""
-    config = {"remount_readonly": True}
-    pair = TokenConfigKeyPair(token="-m", config_key="remount_readonly")
-    
-    job = BackupJob(
-        script_name="backup_path.sh",
-        script_token_config_key_pairs=[pair],
-        config=config,
-        name="test",
-        category="standard_path",
-        repositories=[],
-    )
-    
-    arg_entry = job.get_arg_entry(pair)
-    assert arg_entry == ["-m", "true"]
-
-
 def test_backup_job_get_arg_entry_int():
     """Test get_arg_entry with an integer value."""
     config = {"snapshot_size": 2048}

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -13,7 +13,6 @@ def test_standard_path_token_key_map():
     assert STANDARD_PATH_TOKEN_KEY_MAP["-p"] == "restic_password_file"
     assert STANDARD_PATH_TOKEN_KEY_MAP["-s"] == "backup_source_path"
     assert STANDARD_PATH_TOKEN_KEY_MAP["-e"] == "exclude_paths"
-    assert STANDARD_PATH_TOKEN_KEY_MAP["-m"] == "remount_readonly"
 
 
 def test_logical_volume_token_key_map():


### PR DESCRIPTION
- Simplified backup_path.sh by removing all remount logic
- Removed remount_readonly config parameter from dispatch.py
- Removed --remount-as-ro argument handling from arg_handlers.sh
- Updated usage_commands.sh to remove -m option
- Updated all Python tests to remove remount_readonly assertions
- Updated README to remove remount_readonly documentation
- Removed remount_readonly from all test config files

Rationale: The remount_readonly feature posed safety risks by potentially blocking critical system updates (kernel, bootloader) during backup. Since /boot filesystems are rarely written to and writes are atomic, remounting read-only provided minimal consistency benefit while risking system stability. ResticLVM's focus is LVM snapshots for consistency; standard_path is for boot partitions only.