### PR TITLE
Change snapshot mounts to /tmp/....

### DIFF
--- a/src/resticlvm/scripts/backup_lv_nonroot.sh
+++ b/src/resticlvm/scripts/backup_lv_nonroot.sh
@@ -75,7 +75,8 @@ LV_MOUNT_POINT=$(check_mount_point "$LV_DEVICE_PATH")
 confirm_source_in_lv "$LV_MOUNT_POINT" "$BACKUP_SOURCE_PATH"
 
 # Mount point for snapshot
-SNAPSHOT_MOUNT_POINT="/srv${LV_MOUNT_POINT}"
+MOUNT_BASE=$(generate_mount_base)
+SNAPSHOT_MOUNT_POINT="${MOUNT_BASE}${LV_MOUNT_POINT}"
 
 # Backup path inside the mounted snapshot
 REL_PATH="${BACKUP_SOURCE_PATH#$LV_MOUNT_POINT}"

--- a/src/resticlvm/scripts/backup_lv_root.sh
+++ b/src/resticlvm/scripts/backup_lv_root.sh
@@ -66,7 +66,8 @@ fi
 # ─── Derived Variables ───────────────────────────────────────────
 SNAP_NAME=$(generate_snapshot_name "$VG_NAME" "$LV_NAME")
 LV_DEVICE_PATH="/dev/$VG_NAME/$LV_NAME"
-SNAPSHOT_MOUNT_POINT="/srv/${SNAP_NAME}"
+MOUNT_BASE=$(generate_mount_base)
+SNAPSHOT_MOUNT_POINT="${MOUNT_BASE}/${SNAP_NAME}"
 
 # ─── Pre-checks ───────────────────────────────────────────────────
 check_device_path "$LV_DEVICE_PATH"

--- a/src/resticlvm/scripts/lib/lv_snapshots.sh
+++ b/src/resticlvm/scripts/lib/lv_snapshots.sh
@@ -58,3 +58,10 @@ generate_snapshot_name() {
     timestamp=$(date +"%Y%m%d_%H%M%S")
     echo "${vg_name}_${lv_name}_snapshot_${timestamp}"
 }
+
+# Generate timestamped base directory for snapshot mounts
+generate_mount_base() {
+    local timestamp
+    timestamp=$(date +"%Y%m%d_%H%M%S")
+    echo "/tmp/resticlvm-${timestamp}"
+}


### PR DESCRIPTION
# Improve Snapshot Mount Management and Add Cleanup Documentation

## Summary

This PR improves ResticLVM's handling of temporary snapshot mounts and adds comprehensive documentation for cleaning up after failed backups.

## Changes

### 1. Move Snapshot Mounts to `/tmp/` with Timestamps

**Previously:** Snapshots were mounted under `/srv/` (e.g., `/srv/vg0_lv_root_snapshot_20260114_185220`)

**Now:** Snapshots are mounted under timestamped directories in `/tmp/` (e.g., `/tmp/resticlvm-20260114_185220/vg0_lv_root_snapshot_20260114_185220`)

**Benefits:**
- **Semantically correct:** `/tmp/` is the proper location for temporary operations, not `/srv/`
- **Better troubleshooting:** Timestamps make it easy to identify when lingering mounts were created
- **Easier cleanup identification:** Old timestamps clearly indicate stale mounts from failed backups
- **No collisions:** Each backup run gets its own timestamped directory

**Implementation:**
- Added `generate_mount_base()` function in `lv_snapshots.sh` to create timestamped base directories
- Updated `backup_lv_root.sh` to use `/tmp/resticlvm-<timestamp>/<snap_name>`
- Updated `backup_lv_nonroot.sh` to use `/tmp/resticlvm-<timestamp>/<mount_path>`

### 2. Add Comprehensive Cleanup Documentation

**New "Troubleshooting" section in README:**
- How to identify leftover snapshots, mounts, and directories
- Step-by-step cleanup procedure with examples
- Safety warnings and best practices
- Prevention tips

**New warning in "Running" section:**
- Alerts users to potential leftover resources from failed backups
- Provides quick check commands
- Links to detailed troubleshooting section
- Explains why manual cleanup is currently required

## Why These Changes Matter

**Problem:** When backups fail (e.g., network errors, incorrect credentials, insufficient disk space), ResticLVM leaves behind LVM snapshots and mounted filesystems. Without clear guidance, users may not know how to clean these up, leading to:
- Wasted disk space from lingering snapshots
- Mounted filesystems preventing future backups
- Confusion about what went wrong

**Solution:** 
1. Timestamped mount paths make it obvious which mounts are stale
2. Clear documentation empowers users to safely clean up failed backups
3. Upfront warning prevents surprises

## Future Work

We are evaluating the safest approach for automated cleanup using bash traps or similar mechanisms. For now, manual cleanup ensures users maintain full control over snapshot removal and minimizes risk of accidentally removing snapshots from other tools or workflows.

## Testing

Tested with intentionally failed backups (invalid password files) to verify:
- ✅ Timestamped directories are created correctly
- ✅ Mounts follow the new path structure  
- ✅ Cleanup instructions work as documented
- ✅ No functional regressions in successful backup scenarios

## Files Changed

- `src/resticlvm/scripts/lib/lv_snapshots.sh` - Added `generate_mount_base()` function
- `src/resticlvm/scripts/backup_lv_root.sh` - Updated to use timestamped `/tmp/` mount points
- `src/resticlvm/scripts/backup_lv_nonroot.sh` - Updated to use timestamped `/tmp/` mount points
- `README.md` - Added troubleshooting section and cleanup warning
