### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.2.1] — 2026-01-14
+
+### 🔌 API Changes
+None
+
+### ✨ New Features
+- **B2 helper scripts**: Added four wrapper scripts in `tools/b2/` to simplify Backblaze B2 operations
+  - `run-backup-with-b2.sh`: Run backups with B2 credentials automatically loaded
+  - `restic-b2.sh`: Execute restic commands against B2 repositories
+  - `b2-cli.sh`: Run B2 CLI commands with credentials pre-loaded
+  - `init-b2-repos.sh`: Initialize new restic repositories on B2 (moved from `tools/repo_init/`)
+- **Improved mount management**: Snapshot mounts now use timestamped directories under `/tmp/`
+  - Changed from `/srv/<snapshot_name>` to `/tmp/resticlvm-<timestamp>/<snapshot_name>`
+  - Timestamps make it easy to identify stale mounts from failed backups
+  - Semantically correct location for temporary operations
+
+### 📚 Documentation
+- Added `tools/b2/README.md` with comprehensive B2 helper script documentation
+  - Usage examples for all helper scripts
+  - B2 setup and configuration instructions
+  - Cron job setup examples
+  - Troubleshooting guide
+- Added "Troubleshooting" section to README with cleanup procedures
+  - Step-by-step instructions for cleaning up after failed backups
+  - Commands to identify leftover snapshots, mounts, and directories
+  - Safety warnings and prevention tips
+- Added warning in "Running" section about manual cleanup requirements
+- Reorganized README structure:
+  - Simplified installation section showing latest release
+  - Added "Alternate Installation Methods" section
+  - Renamed "Additional Details" → "Additional Details for Running"
+  - Added "Helper Tools" section highlighting tools directory
+  - Promoted "Development VM" to its own top-level section
+- Deleted `tools/repo_init/README.md` (content migrated to `tools/b2/README.md`)
+
+### 🔧 Internal
+- Added `b2` as optional dependency in `pyproject.toml`
+  - Install with: `pip install "resticlvm[b2]"` or `pip install -e ".[b2]"`
+- Added `generate_mount_base()` function in `lv_snapshots.sh` for timestamped mount directories
+- Updated `backup_lv_root.sh` to use `/tmp/resticlvm-<timestamp>/` mount points
+- Updated `backup_lv_nonroot.sh` to use `/tmp/resticlvm-<timestamp>/` mount points
+
+---
+
 ## [0.2.0] — 2026-01-11
 
 ### 🔌 API Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.2.0"
+version = "0.2.1"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## [0.2.1] — 2026-01-14

### 🔌 API Changes
None

### ✨ New Features
- **B2 helper scripts**: Added four wrapper scripts in `tools/b2/` to simplify Backblaze B2 operations
  - `run-backup-with-b2.sh`: Run backups with B2 credentials automatically loaded
  - `restic-b2.sh`: Execute restic commands against B2 repositories
  - `b2-cli.sh`: Run B2 CLI commands with credentials pre-loaded
  - `init-b2-repos.sh`: Initialize new restic repositories on B2 (moved from `tools/repo_init/`)
- **Improved mount management**: Snapshot mounts now use timestamped directories under `/tmp/`
  - Changed from `/srv/<snapshot_name>` to `/tmp/resticlvm-<timestamp>/<snapshot_name>`
  - Timestamps make it easy to identify stale mounts from failed backups
  - Semantically correct location for temporary operations

### 📚 Documentation
- Added `tools/b2/README.md` with comprehensive B2 helper script documentation
  - Usage examples for all helper scripts
  - B2 setup and configuration instructions
  - Cron job setup examples
  - Troubleshooting guide
- Added "Troubleshooting" section to README with cleanup procedures
  - Step-by-step instructions for cleaning up after failed backups
  - Commands to identify leftover snapshots, mounts, and directories
  - Safety warnings and prevention tips
- Added warning in "Running" section about manual cleanup requirements
- Reorganized README structure:
  - Simplified installation section showing latest release
  - Added "Alternate Installation Methods" section
  - Renamed "Additional Details" → "Additional Details for Running"
  - Added "Helper Tools" section highlighting tools directory
  - Promoted "Development VM" to its own top-level section
- Deleted `tools/repo_init/README.md` (content migrated to `tools/b2/README.md`)

### 🔧 Internal
- Added `b2` as optional dependency in `pyproject.toml`
  - Install with: `pip install "resticlvm[b2]"` or `pip install -e ".[b2]"`
- Added `generate_mount_base()` function in `lv_snapshots.sh` for timestamped mount directories
- Updated `backup_lv_root.sh` to use `/tmp/resticlvm-<timestamp>/` mount points
- Updated `backup_lv_nonroot.sh` to use `/tmp/resticlvm-<timestamp>/` mount points