### PR TITLE
fix: report backup failures and exit non-zero on failure (Critical #1)

### DIFF
--- a/src/resticlvm/orchestration/backup_runner.py
+++ b/src/resticlvm/orchestration/backup_runner.py
@@ -6,6 +6,7 @@ and executes backup jobs based on the specified filters.
 """
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -27,19 +28,39 @@ class BackupJobRunner:
 
     def run_all(
         self, category: Optional[str] = None, name: Optional[str] = None
-    ):
+    ) -> int:
         """Run all backup jobs, optionally filtering by category and/or job name.
+
+        Each job runs in isolation: a failure in one does not stop the others. A
+        summary is printed at the end naming any failed jobs and copy operations.
 
         Args:
             category (str, optional): Backup category to filter by (e.g., 'standard_path').
             name (str, optional): Specific backup job name to run.
+
+        Returns:
+            int: The number of jobs that failed (a failed backup script or any
+            failed copy operation counts as a failed job). 0 means everything
+            succeeded.
         """
+        results = []
         for job in self.jobs:
             if category and job.category != category:
                 continue
             if name and job.name != name:
                 continue
-            job.run()
+            results.append(job.run())
+
+        failures = [r for r in results if not r.ok]
+        print("\n──────── Backup run summary ────────")
+        print(f"  jobs run: {len(results)}   failed: {len(failures)}")
+        for r in failures:
+            if not r.script_ok:
+                print(f"  ❌ {r.category}.{r.name}: backup script failed")
+            for dest in r.failed_copies:
+                print(f"  ❌ {r.category}.{r.name}: copy to {dest} failed")
+
+        return len(failures)
 
 
 def main():
@@ -74,7 +95,9 @@ def main():
 
     plan = BackupPlan(config_path=config_path, dry_run=args.dry_run)
     runner = BackupJobRunner(plan.backup_jobs)
-    runner.run_all(category=args.category, name=args.name)
+    failure_count = runner.run_all(category=args.category, name=args.name)
+    if failure_count:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/resticlvm/orchestration/data_classes.py
+++ b/src/resticlvm/orchestration/data_classes.py
@@ -14,6 +14,21 @@ from resticlvm import scripts
 
 
 @dataclass
+class JobResult:
+    """Outcome of a single BackupJob.run()."""
+
+    category: str
+    name: str
+    script_ok: bool  # did the backup script itself succeed?
+    failed_copies: list  # copy-destination repo_paths that failed (empty if all ok)
+
+    @property
+    def ok(self) -> bool:
+        """True only if the backup script and all copy operations succeeded."""
+        return self.script_ok and not self.failed_copies
+
+
+@dataclass
 class TokenConfigKeyPair:
     """Represents a mapping between a script token and a config file key."""
 
@@ -112,21 +127,24 @@ class BackupJob:
         """
         return ["bash", str(self.script_path)] + self.args_list
 
-    def run(self):
+    def run(self) -> "JobResult":
         """Execute the backup job by running the associated script.
 
-        Raises:
-            subprocess.CalledProcessError: If the script exits with an error code.
-            FileNotFoundError: If the script file is missing.
-            Exception: For any other unexpected errors during execution.
+        Failures are caught (not raised) so that one failed job does not abort the
+        others; the outcome is reported via the returned JobResult instead. Copy
+        operations are only attempted when the backup script itself succeeds.
+
+        Returns:
+            JobResult: The outcome of this job — whether the backup script
+            succeeded and which copy destinations (if any) failed.
         """
         repo_count = len(self.repositories)
         print(f"▶️  Running backup job: [{self.category}.{self.name}] → {repo_count} repo(s)")
-        
+
         # Prepare environment with SSH agent socket for SFTP repositories
         env = os.environ.copy()
         env['SSH_AUTH_SOCK'] = '/root/.ssh/ssh-agent.sock'
-        
+
         try:
             subprocess.run(
                 args=self.cmd,
@@ -136,30 +154,47 @@ class BackupJob:
                 env=env,
             )
             print(f"✅ Backup [{self.category}.{self.name}] completed.\n")
-            
+
             # After successful backup, copy to remote destinations
-            self._run_copy_operations(env)
-            
+            failed_copies = self._run_copy_operations(env)
+            return JobResult(
+                category=self.category,
+                name=self.name,
+                script_ok=True,
+                failed_copies=failed_copies,
+            )
+
         except subprocess.CalledProcessError as e:
             print(f"❌ Command failed [{self.category}.{self.name}]: {e}")
         except FileNotFoundError as e:
             print(f"❌ Script not found [{self.category}.{self.name}]: {e}")
 
-    def _run_copy_operations(self, env: dict):
+        return JobResult(
+            category=self.category,
+            name=self.name,
+            script_ok=False,
+            failed_copies=[],
+        )
+
+    def _run_copy_operations(self, env: dict) -> list:
         """Execute copy operations for repositories with copy_to destinations.
-        
+
         Args:
             env (dict): Environment variables to pass to subprocess.
+
+        Returns:
+            list: Copy-destination repo_paths that failed (empty if all succeeded).
         """
+        failed_copies = []
         for repo in self.repositories:
             if not repo.copy_destinations:
                 continue
-            
+
             for copy_dest in repo.copy_destinations:
                 print(f"🔄 Copying from {repo.repo_path} to {copy_dest.repo_path}...")
-                
+
                 copy_script = pkg_resources.files(scripts) / "copy_repo.sh"
-                
+
                 cmd = [
                     "bash",
                     str(copy_script),
@@ -168,7 +203,7 @@ class BackupJob:
                     "-d", str(copy_dest.repo_path),
                     "-q", str(copy_dest.password_file),
                 ]
-                
+
                 try:
                     subprocess.run(
                         args=cmd,
@@ -180,3 +215,5 @@ class BackupJob:
                     print(f"✅ Copy to {copy_dest.repo_path} completed.\n")
                 except subprocess.CalledProcessError as e:
                     print(f"❌ Copy to {copy_dest.repo_path} failed: {e}\n")
+                    failed_copies.append(copy_dest.repo_path)
+        return failed_copies

--- a/test/test_backup_runner.py
+++ b/test/test_backup_runner.py
@@ -1,0 +1,101 @@
+"""Tests for the backup_runner module (run_all summary + main exit code)."""
+
+from unittest import mock
+
+import pytest
+
+from resticlvm.orchestration import backup_runner
+from resticlvm.orchestration.backup_runner import BackupJobRunner
+from resticlvm.orchestration.data_classes import JobResult
+
+
+def _fake_job(category, name, result):
+    """A stand-in BackupJob whose run() returns a preset JobResult."""
+    job = mock.Mock()
+    job.category = category
+    job.name = name
+    job.run.return_value = result
+    return job
+
+
+def test_run_all_returns_failure_count_and_isolates_jobs():
+    """A failing job is counted but does not stop later jobs from running."""
+    failing = _fake_job(
+        "standard_path", "a",
+        JobResult("standard_path", "a", script_ok=False, failed_copies=[]),
+    )
+    ok = _fake_job(
+        "standard_path", "b",
+        JobResult("standard_path", "b", script_ok=True, failed_copies=[]),
+    )
+
+    runner = BackupJobRunner([failing, ok])
+    failure_count = runner.run_all()
+
+    assert failure_count == 1
+    # Isolation: both jobs ran even though the first failed.
+    failing.run.assert_called_once()
+    ok.run.assert_called_once()
+
+
+def test_run_all_counts_copy_failure_as_job_failure():
+    """A job whose backup succeeded but a copy failed counts as a failure."""
+    job = _fake_job(
+        "standard_path", "a",
+        JobResult("standard_path", "a", script_ok=True,
+                  failed_copies=["/srv/backup/remote"]),
+    )
+
+    assert BackupJobRunner([job]).run_all() == 1
+
+
+def test_run_all_all_success_returns_zero():
+    """All jobs succeeding yields a zero failure count."""
+    jobs = [
+        _fake_job("standard_path", "a",
+                  JobResult("standard_path", "a", script_ok=True, failed_copies=[])),
+        _fake_job("standard_path", "b",
+                  JobResult("standard_path", "b", script_ok=True, failed_copies=[])),
+    ]
+
+    assert BackupJobRunner(jobs).run_all() == 0
+
+
+def test_run_all_respects_category_and_name_filters():
+    """Filtered-out jobs are not run."""
+    a = _fake_job("standard_path", "a",
+                  JobResult("standard_path", "a", script_ok=True, failed_copies=[]))
+    b = _fake_job("logical_volume_root", "b",
+                  JobResult("logical_volume_root", "b", script_ok=True, failed_copies=[]))
+
+    BackupJobRunner([a, b]).run_all(category="standard_path")
+
+    a.run.assert_called_once()
+    b.run.assert_not_called()
+
+
+def _run_main_with_failure_count(monkeypatch, failure_count):
+    """Invoke main() with mocked deps and a forced run_all failure count."""
+    monkeypatch.setattr(backup_runner, "ensure_running_as_root", lambda: None)
+    monkeypatch.setattr(backup_runner, "BackupPlan", mock.Mock())
+    monkeypatch.setattr(
+        BackupJobRunner, "run_all",
+        lambda self, category=None, name=None: failure_count,
+    )
+    monkeypatch.setattr(
+        backup_runner.sys, "argv",
+        ["resticlvm-backup", "--config", "/tmp/config.toml"],
+    )
+    backup_runner.main()
+
+
+def test_main_exits_nonzero_on_failure(monkeypatch):
+    """main() exits with code 1 when any job failed."""
+    with pytest.raises(SystemExit) as exc_info:
+        _run_main_with_failure_count(monkeypatch, failure_count=1)
+    assert exc_info.value.code == 1
+
+
+def test_main_exits_zero_on_success(monkeypatch):
+    """main() returns normally (no SystemExit) when nothing failed."""
+    _run_main_with_failure_count(monkeypatch, failure_count=0)

--- a/test/test_data_classes.py
+++ b/test/test_data_classes.py
@@ -1,14 +1,37 @@
 """Tests for the data_classes module."""
 
+import subprocess
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 from resticlvm.orchestration.data_classes import (
     BackupJob,
+    JobResult,
     TokenConfigKeyPair,
 )
-from resticlvm.orchestration.restic_repo import ResticRepo, ResticPruneKeepParams
+from resticlvm.orchestration.restic_repo import (
+    CopyDestination,
+    ResticRepo,
+    ResticPruneKeepParams,
+)
+
+
+def _make_prune_params():
+    return ResticPruneKeepParams(last=10, daily=7, weekly=4, monthly=6, yearly=1)
+
+
+def _make_job(repositories=None):
+    """Build a minimal BackupJob suitable for exercising run()."""
+    return BackupJob(
+        script_name="backup_path.sh",
+        script_token_config_key_pairs=[],
+        config={},
+        name="test_job",
+        category="standard_path",
+        repositories=repositories if repositories is not None else [],
+    )
 
 
 def test_token_config_key_pair_creation():
@@ -207,3 +230,76 @@ def test_backup_job_cmd():
     assert "backup_path.sh" in cmd[1]
     # Should have -r and -p from the repository
     assert cmd[2:] == ["-r", "/srv/backup/test", "-p", "/tmp/password.txt"]
+
+
+# ─── JobResult / BackupJob.run() outcome reporting ──────────────────────────
+
+
+def test_job_result_ok_property():
+    """JobResult.ok is True only when the script succeeded and no copies failed."""
+    assert JobResult("c", "n", script_ok=True, failed_copies=[]).ok is True
+    assert JobResult("c", "n", script_ok=False, failed_copies=[]).ok is False
+    assert JobResult("c", "n", script_ok=True, failed_copies=["/dest"]).ok is False
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_full_success(mock_run):
+    """A clean backup with no copy destinations returns an ok JobResult."""
+    job = _make_job()
+
+    result = job.run()
+
+    assert result.script_ok is True
+    assert result.failed_copies == []
+    assert result.ok is True
+    mock_run.assert_called_once()
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_script_failure(mock_run):
+    """A failed backup script returns a not-ok JobResult (no exception raised)."""
+    mock_run.side_effect = subprocess.CalledProcessError(1, "bash")
+
+    result = job_result = _make_job().run()
+
+    assert job_result.script_ok is False
+    assert result.ok is False
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_script_missing(mock_run):
+    """A missing script (FileNotFoundError) is reported as a failure, not raised."""
+    mock_run.side_effect = FileNotFoundError("backup_path.sh")
+
+    result = _make_job().run()
+
+    assert result.script_ok is False
+    assert result.ok is False
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_copy_failure(mock_run):
+    """Backup succeeds but a copy fails: script_ok True, copy recorded, not ok."""
+    copy_dest = CopyDestination(
+        repo_path="/srv/backup/remote",
+        password_file=Path("/tmp/remote_pw.txt"),
+        prune_keep_params=_make_prune_params(),
+    )
+    repo = ResticRepo(
+        repo_path=Path("/srv/backup/local"),
+        password_file=Path("/tmp/pw.txt"),
+        prune_keep_params=_make_prune_params(),
+        copy_destinations=[copy_dest],
+    )
+    # First call = backup script (succeeds); second call = copy (fails).
+    mock_run.side_effect = [
+        mock.DEFAULT,
+        subprocess.CalledProcessError(1, "copy_repo.sh"),
+    ]
+
+    result = _make_job(repositories=[repo]).run()
+
+    assert result.script_ok is True
+    assert result.failed_copies == ["/srv/backup/remote"]
+    assert result.ok is False
+    assert mock_run.call_count == 2


### PR DESCRIPTION
## Summary

Fixes **Critical #1** from `docs/PRODUCTION_READINESS_REVIEW.md`: ResticLVM previously **exited 0 even when backup jobs failed**, defeating any exit-code-driven alerting (systemd `OnFailure=`, cron `MAILTO`, success heartbeats). A failed backup looked successful — the worst failure mode for a backup tool.

### Root cause
- `BackupJob.run()` caught subprocess failures, printed them, and returned `None` (no re-raise, no status).
- `_run_copy_operations()` swallowed copy failures the same way.
- `BackupJobRunner.run_all()` ignored job results and `main()` never set an exit status.

## Changes
- **`data_classes.py`** — add a small `JobResult(category, name, script_ok, failed_copies)` dataclass with an `.ok` property; `run()` now returns it instead of swallowing the outcome. Copy operations only run when the backup script succeeds. `_run_copy_operations()` returns the list of failed copy destinations. Stale `Raises CalledProcessError` docstring corrected.
- **`backup_runner.py`** — `run_all()` collects results, prints an end-of-run summary naming which jobs/copies failed, and returns a failure count. `main()` does `sys.exit(1)` if anything failed. A failed backup **or** a failed copy counts as a failure.
- **Job isolation preserved** — one failed job still lets the others run (failures are recorded, not raised).

## Tests
Added unit tests (no VM needed) — `pixi run test` → **44 passed**:
- `run()` outcomes: full success, script failure (`CalledProcessError`), missing script (`FileNotFoundError`), and success-but-copy-failed.
- `JobResult.ok` semantics.
- `run_all()` failure count, copy-failure-counts-as-failure, all-success, filter handling, and job isolation.
- `main()` exits non-zero on failure / returns normally on success (new `test/test_backup_runner.py`).

## Verification
```
pixi run test                          # 44 passed
# manual smoke (on a host with a config):
#   sudo rlvm-backup --config <bad-repo>.toml ; echo "exit=$?"   # -> exit=1 (was 0)
```

## Scope
Critical #2 (LVM cleanup trap) is **out of scope** — tracked in #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)