### PR TITLE
chore: prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.0] — 2026-06-22
+
+### 🔌 API Changes
+- **Backup runs now exit non-zero on failure.** Previously `rlvm-backup` exited 0
+  even when a backup job or copy operation failed, silently defeating exit-code
+  based alerting (systemd `OnFailure=`, cron `MAILTO`, success heartbeats). It now
+  exits 1 if any job or copy fails. **Action:** if you had automation tolerating
+  the old always-0 exit, expect real failures to now surface as exit 1.
+
+### ✨ New Features
+- **End-of-run summary**: after all jobs run, a summary lists how many jobs ran and
+  names any failed jobs and failed copy destinations.
+- Jobs remain isolated — one failed job still lets the others run; failures are
+  reported rather than hidden.
+
+### 🔧 Internal
+- `BackupJob.run()` now returns a `JobResult`; `run_all()` returns a failure count.
+- Added pixi dev environment (`pixi.toml` / `pixi.lock`); run tests with `pixi run test`.
+- Single-sourced the package version in `pyproject.toml` (removed the duplicate from
+  `pixi.toml`).
+- Added a `release-build` pixi task and bundled the `python-build` frontend.
+- Added unit tests covering failure reporting, copy failures, job isolation, and the
+  non-zero exit code.
+
+### ⚠️ Known Limitations
+- A mid-run failure can still leak the LVM snapshot and bind-mounts (no cleanup
+  trap yet) — tracked in #24. Continue running ResticLVM **attended/manual only**
+  until that is fixed.
+
+---
+
 ## [0.2.1] — 2026-01-14
 
 ### 🔌 API Changes

--- a/pixi.lock
+++ b/pixi.lock
@@ -14,6 +14,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
@@ -32,13 +33,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: ./
 packages:
@@ -98,6 +102,19 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21333
   timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+  sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
+  md5: ffc17e785d64e12fc311af9184221839
+  depends:
+  - python >=3.10
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-metadata?source=compressed-mapping
+  size: 34766
+  timestamp: 1779714582554
 - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
   md5: 9614359868482abba1bd15ce465e3c42
@@ -303,6 +320,18 @@ packages:
   - pkg:pypi/pygments?source=hash-mapping
   size: 893031
   timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
+  sha256: 065ac44591da9abf1ff740feb25929554b920b00d09287a551fcced2c9791092
+  md5: d4582021af437c931d7d77ec39007845
+  depends:
+  - python >=3.9
+  - tomli >=1.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyproject-hooks?source=hash-mapping
+  size: 15528
+  timestamp: 1733710122949
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
   md5: 64c98a12c4e23eb238bf66bbecafdf3c
@@ -350,6 +379,25 @@ packages:
   purls: []
   size: 31608571
   timestamp: 1772730708989
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
+  sha256: eb8d5e44fddee9033eb7cfdd5ea584b7594b50e31c7602bef553af0fd4ee9266
+  md5: fa587158c0d768127faa1a3b4df01e5d
+  depends:
+  - python >=3.10
+  - colorama
+  - importlib-metadata >=4.6
+  - packaging >=24.0
+  - pyproject_hooks
+  - tomli >=1.1.0
+  - python
+  constrains:
+  - build <0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/build?source=hash-mapping
+  size: 28946
+  timestamp: 1778048948266
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -364,8 +412,8 @@ packages:
   timestamp: 1765813471974
 - pypi: ./
   name: resticlvm
-  version: 0.2.1
-  sha256: e565a56673ad5e2c15c307442fb9b30ca885869059cd2ae2880573e9a111d82f
+  version: 0.3.0
+  sha256: 79394f49cb5eccf301f841ee8467be4152b03783e4cd0a612e31ea55db052233
   requires_dist:
   - pytest>=7.0 ; extra == 'dev'
   - b2>=3.0 ; extra == 'b2'
@@ -416,6 +464,18 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+  sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
+  md5: ba3dcdc8584155c97c648ae9c044b7a3
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/zipp?source=compressed-mapping
+  size: 24190
+  timestamp: 1779159948016
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,13 +1,15 @@
+# Note: the package version is single-sourced in pyproject.toml; this manifest
+# intentionally omits a [workspace] version so there is only one place to bump.
 [workspace]
 authors = ["Duane Goodner <dmgoodner@gmail.com>"]
 channels = ["conda-forge"]
 name = "resticlvm"
 platforms = ["linux-64"]
-version = "0.2.1"
 
 [dependencies]
 python = ">=3.11,<3.13"
 pytest = ">=7.0"
+python-build = ">=1.0"
 
 [pypi-dependencies]
 resticlvm = { path = ".", editable = true }
@@ -15,3 +17,4 @@ resticlvm = { path = ".", editable = true }
 [tasks]
 test = "python -m pytest"
 pytest = "python -m pytest"
+release-build = "bash tools/release/build-release.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.2.1"
+version = "0.3.0"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release-prep for **v0.3.0** (the Critical #1 silent-failure / exit-code fix). Three things, per the release checklist's Phase 1:

1. **Version bump → 0.3.0**, now **single-sourced** in `pyproject.toml`. Removed the duplicate `version` from `pixi.toml` (the `[workspace] version` is optional and was only cosmetic — the editable install gets its version from `pyproject.toml`). Verified `pixi install` still solves with no version field.
2. **Build frontend in pixi** — added `python-build` (conda-forge 1.5.0, provides `python -m build`) and a `release-build = "bash tools/release/build-release.sh"` task, so the build runs inside the pixi env. Verified `pixi run python -m build --version`.
3. **CHANGELOG** — added the `[0.3.0]` section; headline is the non-zero-exit-on-failure behavior change (filed under 🔌 API Changes), with a ⚠️ Known Limitations note that the LVM cleanup trap (#24) is still pending so runs should stay attended.

`pixi run test` → **44 passed**.

## Why minor (0.2.1 → 0.3.0)

The change alters the CLI's externally-observable exit-code contract (0 → 1 on failure). Under semver — and the pre-1.0 convention where the minor slot carries behavioral changes — that's a minor bump rather than a patch.

## After this merges (Phase 2+)

`git checkout main && git pull` → `pixi run release-build` → verify `resticlvm-0.3.0-*.whl` → tag `v0.3.0`, push tag, GitHub release with the wheel. (Tracked in `docs/scratch/RELEASE_CHECKLIST.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)