### PR TITLE
feat: add --version flag; expose version at runtime

### DIFF
--- a/src/resticlvm/__init__.py
+++ b/src/resticlvm/__init__.py
@@ -1,0 +1,14 @@
+"""ResticLVM — Restic + LVM backup orchestration.
+
+The package version is single-sourced in ``pyproject.toml`` and exposed here at
+runtime via installed package metadata.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("resticlvm")
+except PackageNotFoundError:  # running from a source tree with no installed metadata
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/src/resticlvm/orchestration/backup_runner.py
+++ b/src/resticlvm/orchestration/backup_runner.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from resticlvm import __version__
 from resticlvm.orchestration.backup_plan import BackupPlan
 from resticlvm.orchestration.data_classes import BackupJob
 from resticlvm.orchestration.privileges import ensure_running_as_root
@@ -65,9 +66,12 @@ class BackupJobRunner:
 
 def main():
     """Parse CLI arguments and execute the backup plan."""
-    ensure_running_as_root()
-
     parser = argparse.ArgumentParser(description="Run backup jobs.")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"resticlvm {__version__}",
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -90,6 +94,10 @@ def main():
         help="Path to configuration TOML file.",
     )
     args = parser.parse_args()
+
+    # Root check happens after argument parsing so --version / --help work
+    # without elevation.
+    ensure_running_as_root()
 
     config_path = Path(args.config)
 

--- a/src/resticlvm/orchestration/prune_runner.py
+++ b/src/resticlvm/orchestration/prune_runner.py
@@ -8,6 +8,7 @@ and prunes snapshots according to the configured retention policies.
 import argparse
 from pathlib import Path
 
+from resticlvm import __version__
 from resticlvm.orchestration.config_loader import load_config
 from resticlvm.orchestration.privileges import ensure_running_as_root
 from resticlvm.orchestration.restic_repo import confirm_unique_repos
@@ -19,9 +20,12 @@ def main():
     Raises:
         PermissionError: If the user does not have root privileges.
     """
-    ensure_running_as_root()
-
     parser = argparse.ArgumentParser(description="Prune Restic repositories.")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"resticlvm {__version__}",
+    )
     parser.add_argument(
         "--config",
         required=True,
@@ -43,6 +47,10 @@ def main():
         help="Only prune the repo matching this backup job name.",
     )
     args = parser.parse_args()
+
+    # Root check happens after argument parsing so --version / --help work
+    # without elevation.
+    ensure_running_as_root()
 
     config_path = Path(args.config)
     config = load_config(config_path)

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,47 @@
+"""Tests for runtime version exposure and the --version CLI flag."""
+
+from importlib.metadata import version
+
+import pytest
+
+import resticlvm
+
+
+def test_package_exposes_version():
+    """resticlvm.__version__ is a non-empty string."""
+    assert isinstance(resticlvm.__version__, str)
+    assert resticlvm.__version__
+
+
+def test_version_matches_installed_metadata():
+    """__version__ matches the installed package metadata (single source)."""
+    assert resticlvm.__version__ == version("resticlvm")
+
+
+@pytest.mark.parametrize("module_name", [
+    "resticlvm.orchestration.backup_runner",
+    "resticlvm.orchestration.prune_runner",
+])
+def test_cli_version_flag_no_root_needed(module_name, capsys, monkeypatch):
+    """`--version` prints and exits 0 WITHOUT triggering the root check.
+
+    Regression guard: the root check must run after argument parsing so
+    --version/--help work without elevation.
+    """
+    import importlib
+
+    module = importlib.import_module(module_name)
+
+    # If the root check were reached, this would blow up the test.
+    def _fail_if_called():
+        raise AssertionError("root check ran before --version was handled")
+
+    monkeypatch.setattr(module, "ensure_running_as_root", _fail_if_called)
+    monkeypatch.setattr("sys.argv", [module_name, "--version"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert resticlvm.__version__ in out


### PR DESCRIPTION
## Summary

Item 2 of the post-0.3.0 cleanup: make the version importable at runtime and add a `--version` CLI flag.

- **`src/resticlvm/__init__.py`** now exposes `__version__` via `importlib.metadata.version("resticlvm")` — single-sourced from `pyproject.toml` (no duplicated version string, no `__init__`/metadata drift). Falls back to `0.0.0+unknown` if metadata is absent.
- **`--version`** added to both `rlvm-backup` and `rlvm-prune` (prints `resticlvm X.Y.Z`).
- **Argparse before root check**: `main()` in both entrypoints now parses arguments *before* `ensure_running_as_root()`, so `--version` and `--help` work **without sudo** (previously the root check ran first and blocked them).
- **`test/test_version.py`** covers `__version__`, agreement with installed metadata, and that `--version` is handled before the root check for both entrypoints.

## Verification
- `pixi run test` → **48 passed**.
- `pixi run -- rlvm-backup --version` → `resticlvm 0.3.0` (no sudo); same for `rlvm-prune`.
- `pixi run -- rlvm-backup --help` shows usage (no root error).

## Notes
The argparse-before-root-check reorder is shared with the upcoming Item 3 privilege-model change; this PR owns it. Depends on nothing; can merge independently of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)