### PR TITLE
refactor(tools): decouple B2 creds loading from entrypoint resolution

### DIFF
--- a/docs/EXAMPLE_B2_SETUP.md
+++ b/docs/EXAMPLE_B2_SETUP.md
@@ -123,24 +123,24 @@ applicationKey: K004abc...      → This is your AWS_SECRET_ACCESS_KEY
 
 ```bash
 # Create secure directory (as root)
-sudo mkdir -p /root/.config/restic
-sudo chmod 700 /root/.config/restic
+sudo mkdir -p /root/.config/resticlvm
+sudo chmod 700 /root/.config/resticlvm
 
 # Store B2 credentials
-sudo tee /root/.config/restic/b2-env << 'EOF'
+sudo tee /root/.config/resticlvm/b2-env << 'EOF'
 export AWS_ACCESS_KEY_ID="your-key-id-here"
 export AWS_SECRET_ACCESS_KEY="your-application-key-here"
 EOF
 
 # Secure the file (root read-only)
-sudo chmod 600 /root/.config/restic/b2-env
+sudo chmod 600 /root/.config/resticlvm/b2-env
 ```
 
 ### Verify Credentials
 
 ```bash
 # Source credentials
-sudo bash -c 'source /root/.config/restic/b2-env && echo "Access Key: $AWS_ACCESS_KEY_ID"'
+sudo bash -c 'source /root/.config/resticlvm/b2-env && echo "Access Key: $AWS_ACCESS_KEY_ID"'
 ```
 
 You should see your key ID printed.
@@ -155,7 +155,7 @@ Before using ResticLVM, initialize the repository manually to verify credentials
 
 ```bash
 # Source credentials
-sudo bash -c 'source /root/.config/restic/b2-env && \
+sudo bash -c 'source /root/.config/resticlvm/b2-env && \
   restic -r s3:s3.REGION.backblazeb2.com/BUCKET-NAME/PREFIX \
   init --password-file /path/to/restic-password.txt'
 ```
@@ -167,7 +167,7 @@ sudo bash -c 'source /root/.config/restic/b2-env && \
 
 **Example:**
 ```bash
-sudo bash -c 'source /root/.config/restic/b2-env && \
+sudo bash -c 'source /root/.config/resticlvm/b2-env && \
   restic -r s3:s3.us-west-004.backblazeb2.com/mycompany-backups/resticlvm/root \
   init --password-file /etc/resticlvm/restic-password.txt'
 ```
@@ -244,7 +244,7 @@ ExecStart=/usr/local/bin/rlvm-backup --config /etc/resticlvm/backup.toml
 ```bash
 # Wrapper script: /usr/local/bin/resticlvm-backup-wrapper.sh
 #!/bin/bash
-source /root/.config/restic/b2-env
+source /root/.config/resticlvm/b2-env
 exec rlvm-backup --config /etc/resticlvm/backup.toml
 ```
 
@@ -345,7 +345,7 @@ Check your bucket details in B2 console for the exact region.
 echo $AWS_ACCESS_KEY_ID
 
 # Source credential file
-source /root/.config/restic/b2-env
+source /root/.config/resticlvm/b2-env
 
 # For systemd, add to service file
 Environment="AWS_ACCESS_KEY_ID=..."
@@ -394,7 +394,7 @@ Environment="AWS_ACCESS_KEY_ID=..."
 
 ```bash
 # List snapshots
-sudo bash -c 'source /root/.config/restic/b2-env && \
+sudo bash -c 'source /root/.config/resticlvm/b2-env && \
   restic -r s3:s3.REGION.backblazeb2.com/BUCKET/PREFIX \
   --password-file /etc/resticlvm/restic-password.txt \
   snapshots'
@@ -404,7 +404,7 @@ sudo bash -c 'source /root/.config/restic/b2-env && \
 
 ```bash
 # Check repository consistency
-sudo bash -c 'source /root/.config/restic/b2-env && \
+sudo bash -c 'source /root/.config/resticlvm/b2-env && \
   restic -r s3:s3.REGION.backblazeb2.com/BUCKET/PREFIX \
   --password-file /etc/resticlvm/restic-password.txt \
   check'
@@ -424,7 +424,7 @@ sudo bash -c 'source /root/.config/restic/b2-env && \
 
 ```bash
 # Delete all snapshots and data (DANGEROUS!)
-sudo bash -c 'source /root/.config/restic/b2-env && \
+sudo bash -c 'source /root/.config/resticlvm/b2-env && \
   restic -r s3:s3.REGION.backblazeb2.com/BUCKET/PREFIX \
   --password-file /etc/resticlvm/restic-password.txt \
   forget --prune --keep-last 0'
@@ -450,7 +450,7 @@ Before running first backup, verify:
 - [ ] Lifecycle rule set to "Keep only the last version"
 - [ ] S3-compatible application key created (checkbox checked!)
 - [ ] Credentials saved and stored securely
-- [ ] Environment variables file created (`/root/.config/restic/b2-env`)
+- [ ] Environment variables file created (`/root/.config/resticlvm/b2-env`)
 - [ ] Repository initialized manually with restic
 - [ ] ResticLVM config file created
 - [ ] Test backup runs successfully

--- a/pixi.lock
+++ b/pixi.lock
@@ -38,6 +38,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -419,6 +420,14 @@ packages:
   - b2>=3.0 ; extra == 'b2'
   requires_python: '>=3.11'
   editable: true
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  md5: 59f8f9cfb1dc2f62abdca662823e052a
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 2759145
+  timestamp: 1771524222969
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,7 @@ platforms = ["linux-64"]
 python = ">=3.11,<3.13"
 pytest = ">=7.0"
 python-build = ">=1.0"
+shellcheck = ">=0.9"
 
 [pypi-dependencies]
 resticlvm = { path = ".", editable = true }
@@ -18,3 +19,4 @@ resticlvm = { path = ".", editable = true }
 test = "python -m pytest"
 pytest = "python -m pytest"
 release-build = "bash tools/release/build-release.sh"
+lint-sh = "shellcheck tools/b2/*.sh src/resticlvm/scripts/*.sh src/resticlvm/scripts/lib/*.sh"

--- a/tools/b2/README.md
+++ b/tools/b2/README.md
@@ -2,37 +2,59 @@
 
 This directory contains helper scripts for working with Backblaze B2 cloud storage, including backup operations, repository management, and B2 CLI interactions.
 
-All scripts automatically load B2 credentials from `/root/.config/resticlvm/b2-env`, which should contain:
+All scripts load B2 credentials from `/root/.config/resticlvm/b2-env`, which should contain:
 
 ```bash
 export AWS_ACCESS_KEY_ID=your_b2_key_id
 export AWS_SECRET_ACCESS_KEY=your_b2_application_key
 ```
 
+(Override the location with the `B2_ENV_FILE` environment variable.)
+
 ## Scripts
+
+### 0. with-b2-creds.sh (generic credential loader)
+
+Loads B2 credentials, then `exec`s whatever command you give it. This is the
+building block the backup wrapper uses; reach for it directly when you want to run
+any command with B2 creds loaded.
+
+**Usage:**
+```bash
+sudo ./with-b2-creds.sh -- rlvm-backup --config /path/to/config.toml
+sudo ./with-b2-creds.sh -- restic -r s3:... -p /path/to/pw.txt snapshots
+```
+
+It deliberately does **not** locate any entrypoint — you pass the exact command to
+run, so there is no fragile `which` lookup or PATH guessing.
 
 ### 1. run-backup-with-b2.sh
 
-Wrapper for running `rlvm-backup` with B2 credentials loaded.
+Convenience wrapper for running `rlvm-backup` with B2 credentials loaded. It
+delegates credential-loading to `with-b2-creds.sh` and resolves the `rlvm-backup`
+entrypoint explicitly.
 
 **Purpose:** Execute ResticLVM backups that include B2 repositories.
 
 **Usage:**
 ```bash
-# Run full backup configuration
-sudo env "PATH=$PATH" ./run-backup-with-b2.sh --config /path/to/config.toml
+# Run full backup configuration (rlvm-backup resolved from PATH)
+sudo ./run-backup-with-b2.sh --config /path/to/config.toml
 
-# Run specific backup by name
-sudo env "PATH=$PATH" ./run-backup-with-b2.sh --name boot --config /path/to/config.toml
+# Pin the entrypoint explicitly (recommended for cron/systemd)
+sudo RLVM_BACKUP=/usr/local/bin/rlvm-backup ./run-backup-with-b2.sh --config /path/to/config.toml
 
-# Run category of backups
-sudo env "PATH=$PATH" ./run-backup-with-b2.sh --category standard_path --config /path/to/config.toml
+# Run a specific backup by name / category
+sudo ./run-backup-with-b2.sh --name boot --config /path/to/config.toml
+sudo ./run-backup-with-b2.sh --category standard_path --config /path/to/config.toml
 ```
 
 **Notes:**
-- Automatically sources B2 credentials
-- Ensures LVM commands are in PATH
-- Use `sudo env "PATH=$PATH"` to preserve conda environment
+- Delegates credential-loading to `with-b2-creds.sh` (single responsibility).
+- Resolves `rlvm-backup` via the `RLVM_BACKUP` env var, falling back to a PATH
+  lookup — no fragile bare `which`. Set `RLVM_BACKUP` to an absolute path for
+  unattended runs so resolution never depends on the ambient PATH.
+- Run as root (via `sudo`, or from a root cron/systemd unit).
 
 ### 2. restic-b2.sh
 
@@ -195,14 +217,15 @@ prune_keep_yearly = 1
 
 ## Cron Setup
 
-For automated backups, add to root's crontab (`sudo crontab -e`):
+For automated backups, add to root's crontab (`sudo crontab -e`). Pin the
+entrypoint with an absolute path via `RLVM_BACKUP` so resolution never depends on
+cron's minimal PATH — no need to bake a conda/pixi `bin` directory into the
+crontab `PATH`:
 
 ```cron
-# Set PATH to include conda environment with rlvm-backup
-PATH=/home/username/miniconda3/envs/resticlvm-0.2.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-# Run daily backup at 2 AM
-0 2 * * * /path/to/resticlvm/tools/b2/run-backup-with-b2.sh --config /path/to/config.toml
+# Run daily backup at 2 AM. Set RLVM_BACKUP to the absolute path of the
+# installed entrypoint (find it with: command -v rlvm-backup).
+0 2 * * * RLVM_BACKUP=/usr/local/bin/rlvm-backup /path/to/resticlvm/tools/b2/run-backup-with-b2.sh --config /path/to/config.toml
 ```
 
 ## Troubleshooting

--- a/tools/b2/init-b2-repos.sh
+++ b/tools/b2/init-b2-repos.sh
@@ -39,7 +39,7 @@ Examples:
     root-direct root-copied data-direct data-copied
 
   # With sourced credentials
-  source /root/.config/restic/b2-env
+  source /root/.config/resticlvm/b2-env
   $(basename "$0") -b resticlvm-test -r us-west-004 -P /root/.restic-password \\
     backup/root backup/data
 
@@ -124,7 +124,7 @@ fi
 if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
   echo "Error: B2 credentials not found in environment"
   echo "Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
-  echo "Example: source /root/.config/restic/b2-env"
+  echo "Example: source /root/.config/resticlvm/b2-env"
   exit 1
 fi
 

--- a/tools/b2/run-backup-with-b2.sh
+++ b/tools/b2/run-backup-with-b2.sh
@@ -1,66 +1,43 @@
 #!/bin/bash
 #
-# Wrapper script to run rlvm-backup with B2 credentials loaded
+# Convenience wrapper: run rlvm-backup with B2 credentials loaded.
 #
-# This script sources the B2 environment file containing AWS credentials
-# needed for Backblaze B2 S3-compatible storage, then executes rlvm-backup
-# with any arguments you provide.
+# Credential-loading and entrypoint resolution are now separate concerns:
+#   - B2 credentials are loaded by with-b2-creds.sh (this script delegates to it).
+#   - The rlvm-backup entrypoint is resolved explicitly via the RLVM_BACKUP env
+#     var, falling back to a PATH lookup — no fragile bare `which`.
 #
 # Usage:
-#   ./run-backup-with-b2.sh --config /path/to/config.toml [other options]
-#   ./run-backup-with-b2.sh --name boot --config /path/to/config.toml
-#   ./run-backup-with-b2.sh --category standard_path --config /path/to/config.toml
+#   sudo ./run-backup-with-b2.sh --config /path/to/config.toml [other options]
+#   sudo RLVM_BACKUP=/abs/path/to/rlvm-backup ./run-backup-with-b2.sh --config ...
+#
+# For a fully generic "load B2 creds then run any command", use with-b2-creds.sh:
+#   sudo ./with-b2-creds.sh -- rlvm-backup --config /path/to/config.toml
 #
 # Setup:
-#   1. Create /root/.config/resticlvm/b2-env with your B2 credentials:
-#      export AWS_ACCESS_KEY_ID=your_b2_key_id
-#      export AWS_SECRET_ACCESS_KEY=your_b2_application_key
-#
-#   2. Make this script executable:
-#      chmod +x run-backup-with-b2.sh
-#
-#   3. For cron usage, add to root's crontab:
-#      0 2 * * * /path/to/run-backup-with-b2.sh --config /path/to/config.toml
-#
+#   1. Create /root/.config/resticlvm/b2-env exporting AWS_ACCESS_KEY_ID and
+#      AWS_SECRET_ACCESS_KEY.
+#   2. For cron, run as root and pin the entrypoint with an absolute path, e.g.:
+#      0 2 * * * RLVM_BACKUP=/usr/local/bin/rlvm-backup \
+#        /path/to/run-backup-with-b2.sh --config /path/to/config.toml
 
 set -euo pipefail
 
-# Ensure system binaries are in PATH for LVM commands
+# Ensure system binaries (LVM, etc.) are reachable.
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 
-# Path to the B2 environment file
-B2_ENV_FILE="/root/.config/resticlvm/b2-env"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Check if the environment file exists
-if [[ ! -f "$B2_ENV_FILE" ]]; then
-    echo "❌ Error: B2 environment file not found at $B2_ENV_FILE"
-    echo "   Please create this file with your B2 credentials:"
-    echo "   export AWS_ACCESS_KEY_ID=your_b2_key_id"
-    echo "   export AWS_SECRET_ACCESS_KEY=your_b2_application_key"
-    exit 1
-fi
-
-# Source the B2 credentials
-# shellcheck disable=SC1090
-source "$B2_ENV_FILE"
-
-# Verify credentials were loaded
-if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
-    echo "❌ Error: AWS credentials not found after sourcing $B2_ENV_FILE"
-    echo "   Make sure the file contains:"
-    echo "   export AWS_ACCESS_KEY_ID=your_b2_key_id"
-    echo "   export AWS_SECRET_ACCESS_KEY=your_b2_application_key"
-    exit 1
-fi
-
-# Find rlvm-backup (could be in conda env or system path)
-RLVM_BACKUP=$(which rlvm-backup 2>/dev/null || echo "")
+# Resolve the rlvm-backup entrypoint explicitly: prefer an RLVM_BACKUP override
+# (e.g. an absolute path from cron/systemd), then fall back to a PATH lookup.
+RLVM_BACKUP="${RLVM_BACKUP:-$(command -v rlvm-backup || true)}"
 
 if [[ -z "$RLVM_BACKUP" ]]; then
-    echo "❌ Error: rlvm-backup not found in PATH"
-    echo "   Make sure rlvm-backup is installed and accessible"
+    echo "❌ Error: rlvm-backup not found." >&2
+    echo "   Set RLVM_BACKUP to its absolute path, or ensure it is on PATH." >&2
+    echo "   e.g. sudo RLVM_BACKUP=/usr/local/bin/rlvm-backup $0 --config ..." >&2
     exit 1
 fi
 
-# Execute rlvm-backup with all provided arguments
-exec "$RLVM_BACKUP" "$@"
+# Load B2 creds (separate concern), then run the resolved entrypoint.
+exec "$SCRIPT_DIR/with-b2-creds.sh" -- "$RLVM_BACKUP" "$@"

--- a/tools/b2/with-b2-creds.sh
+++ b/tools/b2/with-b2-creds.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Generic wrapper: load Backblaze B2 (S3-compatible) credentials, then exec the
+# given command.
+#
+# Single responsibility — this script knows nothing about rlvm-backup or any
+# particular entrypoint. It loads credentials and hands off to whatever command
+# you give it. This keeps "load B2 creds" separate from "find/run the program".
+#
+# Usage:
+#   sudo ./with-b2-creds.sh -- <command> [args...]
+#   sudo ./with-b2-creds.sh <command> [args...]
+#
+# Examples:
+#   sudo ./with-b2-creds.sh -- rlvm-backup --config /path/to/config.toml
+#   sudo ./with-b2-creds.sh -- restic -r s3:... -p /path/to/pw.txt snapshots
+#
+# The credentials file (default /root/.config/resticlvm/b2-env, override with the
+# B2_ENV_FILE env var) must export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+
+set -euo pipefail
+
+B2_ENV_FILE="${B2_ENV_FILE:-/root/.config/resticlvm/b2-env}"
+
+# Drop an optional leading "--" separator (so both calling styles work).
+if [[ "${1:-}" == "--" ]]; then
+    shift
+fi
+
+if [[ $# -eq 0 ]]; then
+    echo "❌ Error: no command given." >&2
+    echo "   Usage: $0 -- <command> [args...]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$B2_ENV_FILE" ]]; then
+    echo "❌ Error: B2 environment file not found at $B2_ENV_FILE" >&2
+    echo "   Create it with your B2 credentials:" >&2
+    echo "   export AWS_ACCESS_KEY_ID=your_b2_key_id" >&2
+    echo "   export AWS_SECRET_ACCESS_KEY=your_b2_application_key" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$B2_ENV_FILE"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    echo "❌ Error: AWS credentials not found after sourcing $B2_ENV_FILE" >&2
+    echo "   Make sure the file exports AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY." >&2
+    exit 1
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

Item 3a (structural layer) of the "way of running" cleanup. **No change to backup runtime behavior** — this is about how the wrappers find and invoke things.

- **New `tools/b2/with-b2-creds.sh`** — a generic "load B2 creds, then `exec` the given command" wrapper. Single responsibility: it locates no entrypoint, so there's no fragile `which`/PATH guessing. Supports `-- <cmd>` and a `B2_ENV_FILE` override.
  ```bash
  sudo ./with-b2-creds.sh -- rlvm-backup --config /path/to/config.toml
  ```
- **Reimplemented `run-backup-with-b2.sh`** as a thin shim over `with-b2-creds.sh`. Resolves `rlvm-backup` via an explicit `RLVM_BACKUP` override, falling back to `command -v` — **drops the bare `which`**. Recommends `RLVM_BACKUP=<abs path>` for cron/systemd.
- **Fixed the b2-env path mismatch** — docs and `init-b2-repos.sh` referenced `/root/.config/restic/b2-env`; the code uses `/root/.config/resticlvm/b2-env`. Now consistent everywhere.
- **`tools/b2/README.md`** — documents `with-b2-creds.sh` and replaces the fragile conda-PATH cron example with an absolute-path `RLVM_BACKUP` recipe.
- **Added `shellcheck`** to the pixi dev env + a `lint-sh` task; both b2 wrappers pass.

## Verification
- `pixi run test` → 48 passed.
- `pixi run lint-sh` / `shellcheck` on the wrappers → clean.
- Local smoke (no root/B2 needed): `with-b2-creds.sh -- echo …` loads creds then runs the command; no-command path errors cleanly; `RLVM_BACKUP=/bin/echo run-backup-with-b2.sh --config x` delegates correctly.

## Scope
Behavioral changes (privilege model, `SSH_AUTH_SOCK`) are **Item 3b**, a separate PR that needs rudolph validation. Builds on merged #30/#31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)