### PR TITLE
refactor: assert-and-fail privilege model; respect existing SSH_AUTH_SOCK

### DIFF
--- a/src/resticlvm/orchestration/data_classes.py
+++ b/src/resticlvm/orchestration/data_classes.py
@@ -141,9 +141,11 @@ class BackupJob:
         repo_count = len(self.repositories)
         print(f"▶️  Running backup job: [{self.category}.{self.name}] → {repo_count} repo(s)")
 
-        # Prepare environment with SSH agent socket for SFTP repositories
+        # Prepare environment with SSH agent socket for SFTP repositories.
+        # Respect an SSH_AUTH_SOCK already set by the caller; only fall back to
+        # the conventional root agent socket when none is provided.
         env = os.environ.copy()
-        env['SSH_AUTH_SOCK'] = '/root/.ssh/ssh-agent.sock'
+        env.setdefault('SSH_AUTH_SOCK', '/root/.ssh/ssh-agent.sock')
 
         try:
             subprocess.run(

--- a/src/resticlvm/orchestration/privileges.py
+++ b/src/resticlvm/orchestration/privileges.py
@@ -1,29 +1,31 @@
-"""
-Handles privilege escalation by ensuring the script is running as root.
+"""Ensure the process is running as root.
 
-If the current process is not root, it re-executes itself using sudo.
+ResticLVM needs root for LVM snapshots, mounts, and chroot operations. Rather than
+silently self-elevating with ``sudo``, it requires the caller to run it as root
+(via ``sudo``, a systemd unit, or a root cron job) and fails fast with a clear
+message otherwise.
+
+Self-elevation was removed deliberately: re-running under ``sudo`` scrubs the
+environment, which would drop credentials (e.g. ``AWS_*`` for B2, ``SSH_AUTH_SOCK``)
+loaded by the caller — so "run it as root yourself" is the predictable, composable
+contract.
 """
 
 import os
-import subprocess
 import sys
 
 
 def ensure_running_as_root():
-    """Ensure the current process is running with root privileges.
+    """Exit with a clear error unless the current process is running as root.
 
-    If not running as root, the script re-executes itself with sudo. If
-    privilege escalation fails, the program exits with an error.
-
-    Raises:
-        subprocess.CalledProcessError: If sudo fails to elevate privileges.
+    Does not attempt to elevate privileges. If the effective UID is not 0, prints
+    guidance to stderr and exits with status 1.
     """
     if os.geteuid() != 0:
-        print("🔐 Root privileges required. Elevating with sudo...\n")
-        try:
-            # Re-run the current script with sudo
-            subprocess.check_call(["sudo", sys.executable] + sys.argv)
-        except subprocess.CalledProcessError as e:
-            print(f"❌ Failed to elevate privileges: {e}")
-            sys.exit(1)
-        sys.exit(0)  # Important: exit the current non-root process
+        print(
+            "❌ ResticLVM must be run as root.\n"
+            "   Re-run with sudo, or from a root systemd unit / cron job, e.g.:\n"
+            "       sudo rlvm-backup --config /path/to/config.toml",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/src/resticlvm/scripts/lib/command_runners.sh
+++ b/src/resticlvm/scripts/lib/command_runners.sh
@@ -33,7 +33,7 @@ run_in_chroot_or_echo() {
         echo -e "${DRY_RUN_PREFIX} chroot $*"
     else
         # Pass SSH_AUTH_SOCK to chroot if it's set (needed for SFTP repos)
-        if [ -n "$SSH_AUTH_SOCK" ]; then
+        if [ -n "${SSH_AUTH_SOCK:-}" ]; then
             chroot "$mount_point" /bin/bash -c "export SSH_AUTH_SOCK='$SSH_AUTH_SOCK' && $cmd"
         else
             chroot "$mount_point" /bin/bash -c "$cmd"

--- a/src/resticlvm/scripts/lib/mounts.sh
+++ b/src/resticlvm/scripts/lib/mounts.sh
@@ -112,7 +112,7 @@ bind_chroot_essentials_to_mounted_snapshot() {
     fi
     
     # Bind SSH agent socket directory if it exists (for remote SFTP repos)
-    if [ -n "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+    if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "$SSH_AUTH_SOCK" ]; then
         echo "🔑 Binding SSH agent socket for remote repos..."
         local socket_dir=$(dirname "$SSH_AUTH_SOCK")
         local chroot_socket_dir="$snapshot_mount_point$socket_dir"
@@ -164,7 +164,7 @@ unmount_chroot_essentials() {
     local snapshot_mount_point="$2"
 
     # Unmount SSH agent socket directory first if it was bound
-    if [ -n "$SSH_AUTH_SOCK" ]; then
+    if [ -n "${SSH_AUTH_SOCK:-}" ]; then
         local socket_dir=$(dirname "$SSH_AUTH_SOCK")
         if mountpoint -q "$snapshot_mount_point$socket_dir" 2>/dev/null; then
             run_or_echo "$dry_run" "umount \"$snapshot_mount_point$socket_dir\""

--- a/test/test_data_classes.py
+++ b/test/test_data_classes.py
@@ -303,3 +303,28 @@ def test_run_copy_failure(mock_run):
     assert result.failed_copies == ["/srv/backup/remote"]
     assert result.ok is False
     assert mock_run.call_count == 2
+
+
+# ─── SSH_AUTH_SOCK threading ────────────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_preserves_existing_ssh_auth_sock(mock_run, monkeypatch):
+    """An SSH_AUTH_SOCK already in the environment is respected, not overridden."""
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/custom/agent.sock")
+
+    _make_job().run()
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["SSH_AUTH_SOCK"] == "/custom/agent.sock"
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_defaults_ssh_auth_sock_when_unset(mock_run, monkeypatch):
+    """With no SSH_AUTH_SOCK set, the conventional root agent socket is used."""
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+
+    _make_job().run()
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["SSH_AUTH_SOCK"] == "/root/.ssh/ssh-agent.sock"

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -1,0 +1,22 @@
+"""Tests for the root-privilege check (assert-and-fail, no self-elevation)."""
+
+import pytest
+
+from resticlvm.orchestration import privileges
+
+
+def test_ensure_running_as_root_exits_when_not_root(monkeypatch, capsys):
+    """Non-root invocation exits 1 with a clear message (no sudo re-exec)."""
+    monkeypatch.setattr(privileges.os, "geteuid", lambda: 1000)
+
+    with pytest.raises(SystemExit) as exc_info:
+        privileges.ensure_running_as_root()
+
+    assert exc_info.value.code == 1
+    assert "must be run as root" in capsys.readouterr().err
+
+
+def test_ensure_running_as_root_noop_when_root(monkeypatch):
+    """Running as root is a no-op (returns without raising)."""
+    monkeypatch.setattr(privileges.os, "geteuid", lambda: 0)
+    assert privileges.ensure_running_as_root() is None


### PR DESCRIPTION
## Summary

Item 3b (behavioral layer) of the "way of running" cleanup. **This changes runtime behavior** and should get a rudolph validation pass before we tag 0.4.0.

- **Privilege model → assert-and-fail.** `ensure_running_as_root()` no longer self-re-execs via `sudo`. If not root, it prints a clear "run as root (sudo / systemd / cron)" message and exits 1. Self-elevation was incompatible with credential loading — `sudo` scrubs the environment, dropping `AWS_*` / `SSH_AUTH_SOCK` that the caller (e.g. `with-b2-creds.sh`) just loaded. Drops the now-unused `subprocess` import.
- **`SSH_AUTH_SOCK` respect-existing.** `data_classes.py` uses `env.setdefault('SSH_AUTH_SOCK', '/root/.ssh/ssh-agent.sock')` so a value already set by the caller is honored instead of overridden.
- **Shell `${SSH_AUTH_SOCK:-}` guards.** The three `$SSH_AUTH_SOCK` reads in `lib/command_runners.sh` and `lib/mounts.sh` are now guarded, so running a script directly under `set -u` with no agent no longer crashes with `unbound variable` (the review's Minor item).

## Tests
- `test/test_privileges.py` — exits 1 when not root; no-op when root.
- `test_data_classes.py` — `SSH_AUTH_SOCK` preserved when set, defaulted when unset.
- `pixi run test` → **52 passed**.

## Note on shellcheck
The changed `[ -n "${SSH_AUTH_SOCK:-}" ]` lines are clean. `pixi run lint-sh` still surfaces **pre-existing** warnings elsewhere (e.g. the `eval` in `command_runners.sh` that the production-readiness review explicitly chose not to refactor, and a couple of SC2155 `local x=$(...)` lines) — not introduced here, left for a separate pass.

## Rudolph validation (before tagging 0.4.0)
- Real backup via the new path (`with-b2-creds.sh -- rlvm-backup --config …`) succeeds.
- `rlvm-backup` as **non-root** → exits 1 with the clear message (no sudo prompt).
- `rlvm-backup --version` still works without sudo.
- Re-run the 0.3.0 exit-code smoke test (exit 1, isolation, summary).

Builds on merged #30/#31/#32. After this merges + validates → cut **0.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)