### PR TITLE
docs/security: stop echoing B2 creds; add perms warning + prune/delete note

### DIFF
--- a/docs/EXAMPLE_B2_SETUP.md
+++ b/docs/EXAMPLE_B2_SETUP.md
@@ -139,8 +139,8 @@ sudo chmod 600 /root/.config/resticlvm/b2-env
 ### Verify Credentials
 
 ```bash
-# Source credentials
-sudo bash -c 'source /root/.config/resticlvm/b2-env && echo "Access Key: $AWS_ACCESS_KEY_ID"'
+# Confirm both credentials load, without printing their values
+sudo bash -c 'source /root/.config/resticlvm/b2-env && [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "B2 credentials loaded"'
 ```
 
 You should see your key ID printed.
@@ -367,8 +367,13 @@ Environment="AWS_ACCESS_KEY_ID=..."
 
 ### Application Key Permissions
 
-1. **Bucket-specific keys**: Create separate keys for each bucket
-2. **Least privilege**: Grant only Read and Write (not Delete or List All Buckets unless needed)
+1. **Bucket-specific keys**: scope the key to a single bucket (not "All"), so a
+   leaked key can't reach the rest of your account.
+2. **Least privilege**: grant only what's needed. Note `restic prune`/`forget`
+   require **delete** on the bucket — so a key used for pruning needs it. For
+   stronger ransomware resistance, give the backup host a key **without** delete
+   and run prune separately with a delete-capable key, and/or enable B2 **Object
+   Lock** so existing snapshots can't be altered/removed.
 3. **Key rotation**: Rotate keys periodically (every 90 days recommended)
 4. **Expiration**: Consider setting key expiration dates
 

--- a/tools/b2/README.md
+++ b/tools/b2/README.md
@@ -235,7 +235,8 @@ crontab `PATH`:
 If you see "no credentials found" errors:
 - Verify `/root/.config/resticlvm/b2-env` exists and contains credentials
 - Check file permissions: `sudo chmod 600 /root/.config/resticlvm/b2-env`
-- Ensure credentials are exported: `source /root/.config/resticlvm/b2-env && echo $AWS_ACCESS_KEY_ID`
+- Ensure credentials are exported (checks presence without printing the secret):
+  `sudo bash -c 'source /root/.config/resticlvm/b2-env && [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "credentials are set"'`
 
 ### Command Not Found (b2, rlvm-backup, lvcreate)
 

--- a/tools/b2/with-b2-creds.sh
+++ b/tools/b2/with-b2-creds.sh
@@ -41,6 +41,13 @@ if [[ ! -f "$B2_ENV_FILE" ]]; then
     exit 1
 fi
 
+# Warn (don't fail) if the credentials file is readable by group/other.
+perms="$(stat -c '%a' "$B2_ENV_FILE" 2>/dev/null || true)"
+if [[ -n "$perms" && $(( 8#$perms & 8#077 )) -ne 0 ]]; then
+    echo "⚠️  Warning: $B2_ENV_FILE is accessible to group/other (mode $perms)." >&2
+    echo "   It holds your B2 credentials — restrict it: chmod 600 $B2_ENV_FILE" >&2
+fi
+
 # shellcheck disable=SC1090
 source "$B2_ENV_FILE"
 


### PR DESCRIPTION
## Summary

Small B2 credential-handling hardening, from the pre-release security review of how we store/use `/root/.config/resticlvm/b2-env`.

- **Stop echoing credential values.** The troubleshooting/verify snippets previously did `source … && echo $AWS_ACCESS_KEY_ID`, printing a credential to the terminal. They now check **presence** without printing the value (`tools/b2/README.md`, `docs/EXAMPLE_B2_SETUP.md`).
- **Runtime perms warning.** `with-b2-creds.sh` now warns (without failing) if `b2-env` is readable by group/other, nudging toward `chmod 600`. Verified: silent at mode 600, warns at 644, never blocks the run.
- **Sharpened least-privilege guidance.** The existing "least privilege" bullet implied delete is rarely needed, but `restic prune`/`forget` **require** delete. Clarified that, and noted the split-key (backup key without delete) + B2 **Object Lock** options for ransomware resistance.

## What we deliberately did NOT change
The credential model itself is sound and standard (restic's documented B2-via-S3 `AWS_*` env-var approach; at rest a root-owned `chmod 600` file; in use, env-only — never on argv, never printed, root-visible only, never entering the interactive shell). The docs already steer toward bucket-scoped, least-privilege application keys (Step 4 + Security Best Practices), so no duplication there. Using a **restricted application key** (not an account master key) remains an account-side action for the operator.

## Verification
- `pixi run -- shellcheck tools/b2/with-b2-creds.sh` → clean.
- Perms warning exercised at mode 600 (silent) and 644 (warns, still runs).
- `pixi run test` → 52 passed.

Builds on `main` (has #30–#33). Intended to land before cutting 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)