### PR TITLE
docs: note pixi-env --version staleness and sudo+PATH gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,18 @@ pip install -e ".[dev,b2]"
 
 Changes to the source code are reflected immediately without reinstalling.
 
+> **Two editable-install gotchas:**
+> - **`rlvm-backup --version` can lag.** The reported version comes from the
+>   package *metadata* written at install time, not from `pyproject.toml`. After a
+>   version bump, re-pull won't update it, and `pixi update` / `pixi install` won't
+>   either — force a rebuild: `rm -rf .pixi && pixi install` (pixi) or
+>   `pip install -e . --force-reinstall` (pip). The *code* is always live; only the
+>   printed number lags.
+> - **Running as root from a virtualenv/pixi env.** `sudo` resets `PATH`, so
+>   `sudo rlvm-backup …` may report "command not found" even when `rlvm-backup`
+>   works without `sudo`. Pin the absolute path:
+>   `sudo "$(command -v rlvm-backup)" --config /path/to/config.toml`.
+
 ### CLI Help
 
 To see available options for `rlvm-backup`:

--- a/tools/release/RELEASE_CHECKLIST.md
+++ b/tools/release/RELEASE_CHECKLIST.md
@@ -15,6 +15,8 @@ A reusable, version-agnostic guide for cutting a ResticLVM release. Replace
 - [ ] All substantive changes for the release are merged into `main`.
 - [ ] On the production host: pull latest `main`, set up/refresh the env
       (`pixi install`), and run a **real backup** → succeeds.
+      (When running as root from the pixi env, pin the path —
+      `sudo "$(command -v rlvm-backup)" --config …` — see [pixi-env notes](#pixi-env-notes).)
 - [ ] Run any behavior-specific smoke tests for what changed this release
       (e.g. exit-code behavior, new flags).
 - [ ] Clean `main` checkout: `pixi run test` → all tests pass.
@@ -66,3 +68,24 @@ A reusable, version-agnostic guide for cutting a ResticLVM release. Replace
       confirm version `X.Y.Z` and that `rlvm-backup`/`rlvm-prune` import.
 - [ ] Confirm the GitHub release shows both artifacts and the correct `vX.Y.Z` tag.
 - [ ] If the README pins a "latest release" install tag, bump it to `vX.Y.Z`.
+
+---
+
+## pixi-env notes
+
+Two gotchas when validating from an **editable pixi env** (they do **not** affect a
+real `pip install <wheel>` deployment):
+
+- **`rlvm-backup --version` lags after a bump.** The reported version comes from the
+  package *metadata* snapshot written at install time, not from `pyproject.toml`. A
+  `git pull` updates the code but not that snapshot, and **`pixi update` / `pixi
+  install` won't refresh it either** (a version bump doesn't invalidate the lock for
+  a local editable dep). Force a rebuild:
+  ```bash
+  rm -rf .pixi src/resticlvm.egg-info && pixi install
+  ```
+  The running *code* is always current; only the printed number lags. So don't trust
+  `--version` from an un-rebuilt editable env as a check that you're on new code.
+- **Running as root from the pixi env.** `sudo` resets `PATH`, so `sudo rlvm-backup`
+  may say "command not found" even though `rlvm-backup` works without `sudo`. Pin the
+  absolute path: `sudo "$(command -v rlvm-backup)" --config /path/to/config.toml`.


### PR DESCRIPTION
## Summary

Captures two editable-install gotchas that surfaced during rudolph validation, so the next person doesn't trip on them.

- **`rlvm-backup --version` lags after a version bump.** The reported version is the package *metadata* snapshot written at install time, not `pyproject.toml`. A `git pull` updates code but not that snapshot — and **`pixi update` / `pixi install` don't refresh it either** (a bump doesn't invalidate the lock for a local editable dep). Force a rebuild: `rm -rf .pixi && pixi install`. The running code is always current; only the printed number lags.
- **`sudo rlvm-backup` → "command not found" from a pixi/venv env.** `sudo` resets `PATH`. Pin the absolute path: `sudo "$(command -v rlvm-backup)" --config …`.

## Where
- **README** → "Clone and Install in Development Mode": a short callout with both gotchas.
- **tools/release/RELEASE_CHECKLIST.md** → a new "pixi-env notes" section, plus a Phase 0 cross-reference (the real-backup validation step links to it).

Docs only; `pixi run test` → 66 passed. Neither gotcha affects a real `pip install <wheel>` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)