### PR TITLE
chore: prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.4.0] — 2026-06-23
+
+### 🔌 API Changes
+- **No more automatic privilege elevation.** `rlvm-backup` / `rlvm-prune` no longer
+  re-exec themselves under `sudo`. If not run as root they now print a clear message
+  and exit 1 — run them via `sudo`, a systemd unit, or a root cron job. (Self-elevation
+  was incompatible with credential loading: `sudo` scrubs the environment, dropping
+  `AWS_*` / `SSH_AUTH_SOCK`.)
+- **`tools/b2/run-backup-with-b2.sh` removed.** It's no longer needed — see below.
+  Migrate cron/systemd to `sudo rlvm-backup --config …` (absolute path).
+
+### ✨ New Features
+- **`rlvm-backup` loads B2 credentials natively.** When a config contains a B2 (`s3:`)
+  repository, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are loaded automatically —
+  from the environment if present, else from `/root/.config/resticlvm/b2-env`
+  (override with `RESTICLVM_B2_ENV`). Backups to non-B2 repos run fine with no
+  credentials present. No wrapper, no `RLVM_BACKUP` pinning:
+  `sudo rlvm-backup --config /path/to/config.toml`.
+- **`--version` flag** on `rlvm-backup` and `rlvm-prune` (works without root).
+- **Unmissable failure summary.** When any job fails, the end-of-run summary is a
+  barred `BACKUP FAILED — N of M job(s) did NOT succeed` banner listing each failure;
+  a clean run prints a calm success line.
+
+### 🔧 Internal
+- Version is exposed at runtime via `importlib.metadata` (single-sourced in
+  `pyproject.toml`).
+- `--version` / `--help` are parsed before the root check, so they need no `sudo`.
+- A missing-credentials B2 job fails in isolation (clear message), so other jobs in
+  the same run still execute; the process still exits 1.
+- `SSH_AUTH_SOCK` respects an existing value (`env.setdefault`); shell reads guarded
+  as `${SSH_AUTH_SOCK:-}` under `set -u`.
+- B2 credential-handling hardening: no credential values printed; `b2-env` perms
+  warning; sharpened least-privilege / Object Lock guidance.
+- Tooling/docs: generic release checklist under `tools/release/`; `shellcheck` in the
+  pixi dev env; README/tools docs made consistent with the current run model; removed
+  the now-unused `tools/b2/with-b2-creds.sh`.
+
+### ⚠️ Known Limitations
+- A mid-run failure can still leak the LVM snapshot and bind-mounts (no cleanup trap
+  yet) — tracked in #24. Continue running ResticLVM **attended/manual only** until
+  that is fixed.
+
+---
+
 ## [0.3.0] — 2026-06-22
 
 ### 🔌 API Changes

--- a/pixi.lock
+++ b/pixi.lock
@@ -413,8 +413,8 @@ packages:
   timestamp: 1765813471974
 - pypi: ./
   name: resticlvm
-  version: 0.3.0
-  sha256: 79394f49cb5eccf301f841ee8467be4152b03783e4cd0a612e31ea55db052233
+  version: 0.4.0
+  sha256: fa40ea13e297b850bfd8092c12e96f195bc653d868dc462cd427b61f086f7d9c
   requires_dist:
   - pytest>=7.0 ; extra == 'dev'
   - b2>=3.0 ; extra == 'b2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.3.0"
+version = "0.4.0"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Phase 1 of the 0.4.0 release: bump `pyproject.toml` → `0.4.0` (single source) and add the CHANGELOG `[0.4.0]` section.

### Why minor (0.3.0 → 0.4.0)
This release changes externally-observable behavior — `rlvm-backup` no longer self-elevates (requires root, exits 1 otherwise), a wrapper script was removed, and a `--version` flag was added — so it's a minor bump.

### CHANGELOG `[0.4.0]` headlines
- ✨ `rlvm-backup` loads B2 credentials natively (no wrapper, no `RLVM_BACKUP` pinning); `--version` flag; unmissable failure banner.
- 🔌 no automatic `sudo` self-elevation (run as root / exit 1); `run-backup-with-b2.sh` removed.
- 🔧 runtime version via `importlib.metadata`; isolated B2-credential failures; `SSH_AUTH_SOCK` respect-existing + `${SSH_AUTH_SOCK:-}` guards; credential hardening; generic release checklist; shellcheck in dev env; README/doc consistency; removed unused `with-b2-creds.sh`.
- ⚠️ #24 (LVM cleanup trap) still open → attended runs only.

`pixi run test` → **66 passed**. `pixi.lock` updated for the editable package version bump.

## After merge (Phase 2+)
`git checkout main && git pull` → `pixi run release-build` → verify `resticlvm-0.4.0` wheel + sdist → tag `v0.4.0` + GitHub release with both artifacts. (Per `tools/release/RELEASE_CHECKLIST.md`. I'll pause for explicit OK before the public tag/release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)