### PR TITLE
docs: add CLAUDE.md for agent kickoff context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# ResticLVM — agent context
+
+Config-driven LVM-snapshot backups stored with Restic. A thin Python CLI/orchestration
+layer (`src/resticlvm/orchestration`) drives focused Bash scripts
+(`src/resticlvm/scripts`) that do the LVM/Restic work.
+
+## Dev environment (pixi)
+
+- `pixi install` — set up the env (Python, pytest, shellcheck, python-build; editable
+  install of resticlvm).
+- `pixi run test` — run the pytest suite (no VM needed).
+- `pixi run lint-sh` — shellcheck the shell scripts.
+- `pixi run release-build` — build the wheel + sdist.
+- Use pixi, not conda/venv. See the README "Development" section for `pixi.lock`
+  handling and the editable-install `--version` gotcha (force a rebuild with
+  `rm -rf .pixi && pixi install` after a version bump).
+
+## Running as root (require-root model)
+
+- `rlvm-backup` / `rlvm-prune` require root and exit 1 otherwise — they do **not**
+  self-elevate.
+- From the pixi env, `sudo` scrubs `PATH`, so pin the entrypoint:
+  `sudo "$(command -v rlvm-backup)" --config <config>`.
+
+## Conventions
+
+- PR-based: branch off `main`, open a PR with `gh`, never commit directly to `main`.
+- The version is single-sourced in `pyproject.toml` and exposed at runtime via
+  `importlib.metadata`.
+- Releases follow `tools/release/RELEASE_CHECKLIST.md` (wheel + sdist; annotated tag;
+  build with `pixi run release-build`).
+
+## Status & next work
+
+- Pre-1.0. Run **attended**: a mid-run failure can leak the LVM snapshot and its
+  mounts (cleanup-on-failure is not yet automatic).
+- **Next major task: Critical #2 / issue #24** (the LVM cleanup trap). Start there.
+  - Background: `docs/PRODUCTION_READINESS_REVIEW.md` (Critical #2) and issue #24
+    itself, which lists 4 open design questions.
+  - Needs a VM with LVM for failure-injection testing: see `dev/vm-builder/`.


### PR DESCRIPTION
## Summary

Adds a root `CLAUDE.md` so a fresh Claude Code session — on **any** machine — starts with the project's working context. Unlike machine-local memory (`MEMORY.md`), `CLAUDE.md` travels with the repo via git and auto-loads.

It captures the conventions a cold session wouldn't otherwise know:
- **Dev environment** — pixi (`pixi install` / `pixi run test` / `lint-sh` / `release-build`), and a pointer to the README for `pixi.lock` + editable `--version` gotchas.
- **Require-root run model** — exit 1 if not root (no self-elevation); `sudo "$(command -v rlvm-backup)" …` from a pixi env.
- **Conventions** — PR-based workflow, single-sourced version, release checklist.
- **Status & next work** — pre-1.0/attended-only, and a direct pointer to **Critical #2 / issue #24** (the LVM cleanup trap) with its background docs and the `dev/vm-builder/` VM rig.

The technical "what to fix" already lives in issue #24 and `docs/PRODUCTION_READINESS_REVIEW.md`; this adds the "how we work here" so resuming #24 is smooth.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)