### PR TITLE
Unify CLI into single rlvm command with subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ layer (`src/resticlvm/orchestration`) drives focused Bash scripts
 
 ## Running as root (require-root model)
 
-- `rlvm-backup` / `rlvm-prune` require root and exit 1 otherwise — they do **not**
+- `rlvm backup` / `rlvm prune` require root and exit 1 otherwise — they do **not**
   self-elevate.
 - From the pixi env, `sudo` scrubs `PATH`, so pin the entrypoint:
-  `sudo "$(command -v rlvm-backup)" --config <config>`.
+  `sudo "$(command -v rlvm)" backup --config <config>`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ exclude_paths = []
 EOF
 
 # 4. Preview, then run (must be root)
-sudo rlvm-backup --config backup.toml --dry-run
-sudo rlvm-backup --config backup.toml
+sudo rlvm backup --config backup.toml --dry-run
+sudo rlvm backup --config backup.toml
 ```
 
 For the full configuration reference (multiple/remote/cloud repositories, `copy_to`, root and standard-partition backups), see [Config File Setup](#config-file-setup).
@@ -118,9 +118,9 @@ pip install git+https://github.com/duanegoodner/resticlvm.git@v0.4.1
 
 This installs the CLI tools:
 
-- `rlvm-backup`: Run backup jobs as defined in your configuration file.
+- `rlvm backup`: Run backup jobs as defined in your configuration file.
 
-- `rlvm-prune`: Prune Restic snapshots according to the retention settings in your configuration.
+- `rlvm prune`: Prune Restic snapshots according to the retention settings in your configuration.
 
 For other installation methods, see [Alternate Installation Methods](#alternate-installation-methods).
 
@@ -341,13 +341,13 @@ exclude_paths = []
 Run all backup jobs defined in a config (ResticLVM must run as root):
 
 ```bash
-sudo rlvm-backup --config /path/to/your/backup-config.toml
+sudo rlvm backup --config /path/to/your/backup-config.toml
 ```
 
 Preview what would happen, without writing any backups, using `--dry-run`:
 
 ```bash
-sudo rlvm-backup --config /path/to/your/backup-config.toml --dry-run
+sudo rlvm backup --config /path/to/your/backup-config.toml --dry-run
 ```
 
 See [below](#running-specific-jobs-from-config-file) for running specific (not all) jobs from a config file.
@@ -398,10 +398,10 @@ The `--category` and/or `--name` options can be used if we only want to run some
 
 ```
 # Run all jobs in a category
-sudo rlvm-backup --config /path/to/resticlvm_config.toml --category standard_path
+sudo rlvm backup --config /path/to/resticlvm_config.toml --category standard_path
 
 # Run a single specific job
-sudo rlvm-backup --config /path/to/resticlvm_config.toml --category standard_path --name boot
+sudo rlvm backup --config /path/to/resticlvm_config.toml --category standard_path --name boot
 ```
 
 ### Data Transfer Methods
@@ -435,7 +435,7 @@ restic -r s3:s3.us-west-004.backblazeb2.com/bucket-name/path init
 ```
 
 For automated runs you don't need to export these yourself: when a config contains
-a B2 (`s3:`) repo, `rlvm-backup` loads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+a B2 (`s3:`) repo, `rlvm backup` loads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
 from `/root/.config/resticlvm/b2-env` automatically (credentials already in the
 environment take precedence). Backups to non-B2 repos run fine with no credentials
 present.
@@ -473,7 +473,7 @@ See [Restic documentation](https://restic.readthedocs.io/en/stable/030_preparing
 #### Prune All Configured Repositories
 
 ```bash
-sudo rlvm-prune --config /path/to/your/resticlvm_config.toml
+sudo rlvm prune --config /path/to/your/resticlvm_config.toml
 ```
 - Applies the configured prune_keep_* settings to each Restic repo.
 
@@ -484,10 +484,10 @@ sudo rlvm-prune --config /path/to/your/resticlvm_config.toml
 We can also choose to prune only certain repos:
 ```
 # Prune by category
-sudo rlvm-prune --config /path/to/resticlvm_config.toml --category logical_volume_root
+sudo rlvm prune --config /path/to/resticlvm_config.toml --category logical_volume_root
 
 # Prune by specific job name
-sudo rlvm-prune --config /path/to/resticlvm_config.toml --category logical_volume_root --name lv_root
+sudo rlvm prune --config /path/to/resticlvm_config.toml --category logical_volume_root --name lv_root
 ```
 
 #### Protecting Specific Snapshots from Deletion
@@ -575,9 +575,9 @@ Both commands accept `--config`, `--category`, `--name`, `--dry-run`, `--version
 requires root.
 
 ```bash
-rlvm-backup --help      # full option list
-rlvm-backup --version   # print the installed version (no root needed)
-rlvm-prune --help
+rlvm backup --help      # full option list
+rlvm backup --version   # print the installed version (no root needed)
+rlvm prune --help
 ```
 
 ## Helper Tools
@@ -631,7 +631,7 @@ Pixi rewrites it whenever it re-solves (`pixi install` / `pixi update`), so a st
 
 #### `--version` can lag in an editable install
 
-`rlvm-backup --version` reads the package *metadata* snapshot written at install
+`rlvm backup --version` reads the package *metadata* snapshot written at install
 time, **not** `pyproject.toml`. After a version bump, a `git pull` updates the code
 but not that snapshot, and `pixi install` / `pixi update` won't refresh it either.
 Force a full rebuild:
@@ -645,11 +645,11 @@ The running *code* is always current; only the printed number lags. (A real
 
 #### Running as root from the pixi env
 
-`sudo` resets `PATH`, so `sudo rlvm-backup …` may report "command not found" even
-when `rlvm-backup` works without `sudo`. Pin the absolute path:
+`sudo` resets `PATH`, so `sudo rlvm backup …` may report "command not found" even
+when `rlvm` works without `sudo`. Pin the absolute path:
 
 ```bash
-sudo "$(command -v rlvm-backup)" --config /path/to/config.toml
+sudo "$(command -v rlvm)" backup --config /path/to/config.toml
 ```
 
 ### LVM Test VM

--- a/docs/EXAMPLE_B2_SETUP.md
+++ b/docs/EXAMPLE_B2_SETUP.md
@@ -229,15 +229,15 @@ prune_keep_yearly = 1
 
 ## Step 8: Automation
 
-`rlvm-backup` loads B2 credentials from `/root/.config/resticlvm/b2-env` itself when
+`rlvm backup` loads B2 credentials from `/root/.config/resticlvm/b2-env` itself when
 a config contains an `s3:` repo, so automation needs **no wrapper script** — just
-run `rlvm-backup` as root.
+run `rlvm backup` as root.
 
 ### Cron
 
 ```cron
 # Crontab entry (sudo crontab -e). Absolute path so cron's minimal PATH is irrelevant.
-0 2 * * * /usr/local/bin/rlvm-backup --config /etc/resticlvm/backup.toml
+0 2 * * * /usr/local/bin/rlvm backup --config /etc/resticlvm/backup.toml
 ```
 
 ### Systemd
@@ -246,7 +246,7 @@ run `rlvm-backup` as root.
 # /etc/systemd/system/resticlvm-backup.service
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/rlvm-backup --config /etc/resticlvm/backup.toml
+ExecStart=/usr/local/bin/rlvm backup --config /etc/resticlvm/backup.toml
 ```
 
 Credentials already present in the environment take precedence over the b2-env file,

--- a/docs/EXAMPLE_SSH_SETUP.md
+++ b/docs/EXAMPLE_SSH_SETUP.md
@@ -172,7 +172,7 @@ sudo backup-ssh-status
 Once the agent is running with the key loaded, backups work automatically:
 
 ```bash
-rlvm-backup --config /path/to/config.toml
+rlvm backup --config /path/to/config.toml
 # No passphrase prompt - uses agent!
 ```
 
@@ -200,7 +200,7 @@ if ! ssh-add -l &>/dev/null; then
 fi
 
 # Run backup
-/usr/local/bin/rlvm-backup --config /etc/resticlvm/backup.toml &> "$LOGFILE"
+/usr/local/bin/rlvm backup --config /etc/resticlvm/backup.toml &> "$LOGFILE"
 
 EXIT_CODE=$?
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -414,7 +414,7 @@ packages:
 - pypi: ./
   name: resticlvm
   version: 0.4.1
-  sha256: 5aa664630ca83dbd35a119f56b4e0bc753e69bc15c4b1973407abef7c888cef5
+  sha256: 6f76158fc67a163ebedb24ba6fb337a60624366a99d1a29aca3c6802ced2880d
   requires_dist:
   - pytest>=7.0 ; extra == 'dev'
   - b2>=3.0 ; extra == 'b2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dev = ["pytest>=7.0"]
 b2 = ["b2>=3.0"]
 
 [project.scripts]
-rlvm-backup = "resticlvm.orchestration.backup_runner:main"
-rlvm-prune = "resticlvm.orchestration.prune_runner:main"
+rlvm = "resticlvm.orchestration.cli:main"
 
 [tool.black]
 line-length = 79

--- a/src/resticlvm/orchestration/backup_runner.py
+++ b/src/resticlvm/orchestration/backup_runner.py
@@ -73,6 +73,21 @@ class BackupJobRunner:
         return len(failures)
 
 
+def run(args):
+    """Execute the backup plan from pre-parsed arguments.
+
+    Args:
+        args: Namespace with config, dry_run, category, and name attributes.
+    """
+    config_path = Path(args.config)
+
+    plan = BackupPlan(config_path=config_path, dry_run=args.dry_run)
+    runner = BackupJobRunner(plan.backup_jobs)
+    failure_count = runner.run_all(category=args.category, name=args.name)
+    if failure_count:
+        sys.exit(1)
+
+
 def main():
     """Parse CLI arguments and execute the backup plan."""
     parser = argparse.ArgumentParser(description="Run backup jobs.")
@@ -108,13 +123,7 @@ def main():
     # without elevation.
     ensure_running_as_root()
 
-    config_path = Path(args.config)
-
-    plan = BackupPlan(config_path=config_path, dry_run=args.dry_run)
-    runner = BackupJobRunner(plan.backup_jobs)
-    failure_count = runner.run_all(category=args.category, name=args.name)
-    if failure_count:
-        sys.exit(1)
+    run(args)
 
 
 if __name__ == "__main__":

--- a/src/resticlvm/orchestration/cli.py
+++ b/src/resticlvm/orchestration/cli.py
@@ -1,0 +1,75 @@
+"""Unified CLI entry point for ResticLVM."""
+
+import argparse
+import sys
+
+from resticlvm import __version__
+from resticlvm.orchestration.privileges import ensure_running_as_root
+
+
+def _add_common_arguments(parser):
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to configuration TOML file.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without actually running.",
+    )
+    parser.add_argument(
+        "--category",
+        type=str,
+        help="Only operate on this backup category.",
+    )
+    parser.add_argument(
+        "--name",
+        type=str,
+        help="Only operate on this specific job name.",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="rlvm",
+        description="ResticLVM — config-driven LVM-snapshot backups with Restic.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"resticlvm {__version__}",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    backup_parser = subparsers.add_parser(
+        "backup", help="Run backup jobs."
+    )
+    _add_common_arguments(backup_parser)
+
+    prune_parser = subparsers.add_parser(
+        "prune", help="Prune Restic snapshots."
+    )
+    _add_common_arguments(prune_parser)
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(0)
+
+    ensure_running_as_root()
+
+    if args.command == "backup":
+        from resticlvm.orchestration.backup_runner import run as run_backup
+
+        run_backup(args)
+    elif args.command == "prune":
+        from resticlvm.orchestration.prune_runner import run as run_prune
+
+        run_prune(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/resticlvm/orchestration/credentials.py
+++ b/src/resticlvm/orchestration/credentials.py
@@ -2,7 +2,7 @@
 
 ResticLVM backs up to B2 via restic's S3-compatible backend (`s3:` repos), which
 authenticates with ``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``. Rather than
-requiring a separate credential-loading wrapper, ``rlvm-backup`` loads these itself
+requiring a separate credential-loading wrapper, ``rlvm backup`` loads these itself
 when — and only when — a job actually targets a B2 repo. Jobs with no B2 repo run
 without any credentials present.
 

--- a/src/resticlvm/orchestration/privileges.py
+++ b/src/resticlvm/orchestration/privileges.py
@@ -25,7 +25,7 @@ def ensure_running_as_root():
         print(
             "❌ ResticLVM must be run as root.\n"
             "   Re-run with sudo, or from a root systemd unit / cron job, e.g.:\n"
-            "       sudo rlvm-backup --config /path/to/config.toml",
+            "       sudo rlvm backup --config /path/to/config.toml",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/resticlvm/orchestration/prune_runner.py
+++ b/src/resticlvm/orchestration/prune_runner.py
@@ -14,12 +14,29 @@ from resticlvm.orchestration.privileges import ensure_running_as_root
 from resticlvm.orchestration.restic_repo import confirm_unique_repos
 
 
-def main():
-    """Parse CLI arguments and execute prune operations for Restic repositories.
+def run(args):
+    """Execute prune operations from pre-parsed arguments.
 
-    Raises:
-        PermissionError: If the user does not have root privileges.
+    Args:
+        args: Namespace with config, dry_run, category, and name attributes.
     """
+    config_path = Path(args.config)
+    config = load_config(config_path)
+
+    restic_repos = confirm_unique_repos(config=config)
+
+    for (category, name), repos in restic_repos.items():
+        if args.category and category != args.category:
+            continue
+        if args.name and name != args.name:
+            continue
+
+        for repo in repos:
+            repo.prune(dry_run=args.dry_run)
+
+
+def main():
+    """Parse CLI arguments and execute prune operations for Restic repositories."""
     parser = argparse.ArgumentParser(description="Prune Restic repositories.")
     parser.add_argument(
         "--version",
@@ -52,19 +69,7 @@ def main():
     # without elevation.
     ensure_running_as_root()
 
-    config_path = Path(args.config)
-    config = load_config(config_path)
-
-    restic_repos = confirm_unique_repos(config=config)
-
-    for (category, name), repos in restic_repos.items():
-        if args.category and category != args.category:
-            continue
-        if args.name and name != args.name:
-            continue
-
-        for repo in repos:
-            repo.prune(dry_run=args.dry_run)
+    run(args)
 
 
 if __name__ == "__main__":

--- a/test/test_backup_runner.py
+++ b/test/test_backup_runner.py
@@ -104,28 +104,29 @@ def test_run_all_respects_category_and_name_filters():
     b.run.assert_not_called()
 
 
-def _run_main_with_failure_count(monkeypatch, failure_count):
-    """Invoke main() with mocked deps and a forced run_all failure count."""
-    monkeypatch.setattr(backup_runner, "ensure_running_as_root", lambda: None)
+def _run_with_failure_count(monkeypatch, failure_count):
+    """Invoke run() with mocked deps and a forced run_all failure count."""
     monkeypatch.setattr(backup_runner, "BackupPlan", mock.Mock())
     monkeypatch.setattr(
         BackupJobRunner, "run_all",
         lambda self, category=None, name=None: failure_count,
     )
-    monkeypatch.setattr(
-        backup_runner.sys, "argv",
-        ["resticlvm-backup", "--config", "/tmp/config.toml"],
+    args = mock.Mock(
+        config="/tmp/config.toml",
+        dry_run=False,
+        category=None,
+        name=None,
     )
-    backup_runner.main()
+    backup_runner.run(args)
 
 
-def test_main_exits_nonzero_on_failure(monkeypatch):
-    """main() exits with code 1 when any job failed."""
+def test_run_exits_nonzero_on_failure(monkeypatch):
+    """run() exits with code 1 when any job failed."""
     with pytest.raises(SystemExit) as exc_info:
-        _run_main_with_failure_count(monkeypatch, failure_count=1)
+        _run_with_failure_count(monkeypatch, failure_count=1)
     assert exc_info.value.code == 1
 
 
-def test_main_exits_zero_on_success(monkeypatch):
-    """main() returns normally (no SystemExit) when nothing failed."""
-    _run_main_with_failure_count(monkeypatch, failure_count=0)
+def test_run_exits_zero_on_success(monkeypatch):
+    """run() returns normally (no SystemExit) when nothing failed."""
+    _run_with_failure_count(monkeypatch, failure_count=0)

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -18,29 +18,22 @@ def test_version_matches_installed_metadata():
     assert resticlvm.__version__ == version("resticlvm")
 
 
-@pytest.mark.parametrize("module_name", [
-    "resticlvm.orchestration.backup_runner",
-    "resticlvm.orchestration.prune_runner",
-])
-def test_cli_version_flag_no_root_needed(module_name, capsys, monkeypatch):
-    """`--version` prints and exits 0 WITHOUT triggering the root check.
+def test_cli_version_flag_no_root_needed(capsys, monkeypatch):
+    """`rlvm --version` prints and exits 0 WITHOUT triggering the root check.
 
     Regression guard: the root check must run after argument parsing so
     --version/--help work without elevation.
     """
-    import importlib
+    from resticlvm.orchestration import cli
 
-    module = importlib.import_module(module_name)
-
-    # If the root check were reached, this would blow up the test.
     def _fail_if_called():
         raise AssertionError("root check ran before --version was handled")
 
-    monkeypatch.setattr(module, "ensure_running_as_root", _fail_if_called)
-    monkeypatch.setattr("sys.argv", [module_name, "--version"])
+    monkeypatch.setattr(cli, "ensure_running_as_root", _fail_if_called)
+    monkeypatch.setattr("sys.argv", ["rlvm", "--version"])
 
     with pytest.raises(SystemExit) as exc_info:
-        module.main()
+        cli.main()
 
     assert exc_info.value.code == 0
     out = capsys.readouterr().out

--- a/tools/b2/README.md
+++ b/tools/b2/README.md
@@ -3,10 +3,10 @@
 This directory contains helper scripts for working with Backblaze B2 cloud storage:
 repository management and manual B2/restic interactions.
 
-> **Running backups no longer needs a wrapper.** `rlvm-backup` loads B2 credentials
+> **Running backups no longer needs a wrapper.** `rlvm backup` loads B2 credentials
 > itself whenever a config contains a B2 (`s3:`) repository, so you just run:
 > ```bash
-> sudo rlvm-backup --config /path/to/config.toml
+> sudo rlvm backup --config /path/to/config.toml
 > ```
 > Backups to non-B2 repos run fine with no credentials present. See
 > [Credentials](#credentials) for where the keys come from.
@@ -21,7 +21,7 @@ export AWS_SECRET_ACCESS_KEY=your_b2_application_key
 ```
 
 Credentials already present in the environment (e.g. a systemd `Environment=`, or
-exported in your shell) take precedence over this file. `rlvm-backup` reads the file
+exported in your shell) take precedence over this file. `rlvm backup` reads the file
 via `RESTICLVM_B2_ENV` if set, else the default path above; the helper scripts below
 read it from the default path.
 
@@ -191,15 +191,15 @@ prune_keep_yearly = 1
 
 ## Cron Setup
 
-For automated backups, add to root's crontab (`sudo crontab -e`). `rlvm-backup`
+For automated backups, add to root's crontab (`sudo crontab -e`). `rlvm backup`
 loads B2 credentials itself, so no wrapper is needed — just call it by its absolute
-path (find it with `command -v rlvm-backup`) so cron's minimal `PATH` doesn't
+path (find it with `command -v rlvm`) so cron's minimal `PATH` doesn't
 matter:
 
 ```cron
-# Run daily backup at 2 AM (as root). rlvm-backup loads B2 creds from
+# Run daily backup at 2 AM (as root). rlvm backup loads B2 creds from
 # /root/.config/resticlvm/b2-env when the config has an s3: repo.
-0 2 * * * /usr/local/bin/rlvm-backup --config /path/to/config.toml
+0 2 * * * /usr/local/bin/rlvm backup --config /path/to/config.toml
 ```
 
 ## Troubleshooting
@@ -212,11 +212,11 @@ If you see "no credentials found" errors:
 - Ensure credentials are exported (checks presence without printing the secret):
   `sudo bash -c 'source /root/.config/resticlvm/b2-env && [ -n "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "credentials are set"'`
 
-### Command Not Found (b2, rlvm-backup, lvcreate)
+### Command Not Found (b2, rlvm backup, lvcreate)
 
 `sudo` resets `PATH`, so a command installed in a virtualenv/pixi env may not be found:
-- **rlvm-backup:** pin its absolute path — `sudo "$(command -v rlvm-backup)" --config …`
-  (or use the system install path, e.g. `/usr/local/bin/rlvm-backup`).
+- **rlvm:** pin its absolute path — `sudo "$(command -v rlvm)" backup --config …`
+  (or use the system install path, e.g. `/usr/local/bin/rlvm backup`).
 - **b2 / restic CLIs** (via these helper scripts): preserve your `PATH` —
   `sudo env "PATH=$PATH" ./b2-cli.sh …`.
 - **For cron jobs**, call binaries by absolute path (cron's `PATH` is minimal).

--- a/tools/release/RELEASE_CHECKLIST.md
+++ b/tools/release/RELEASE_CHECKLIST.md
@@ -16,7 +16,7 @@ A reusable, version-agnostic guide for cutting a ResticLVM release. Replace
 - [ ] On the production host: pull latest `main`, set up/refresh the env
       (`pixi install`), and run a **real backup** → succeeds.
       (When running as root from the pixi env, pin the path —
-      `sudo "$(command -v rlvm-backup)" --config …` — see [pixi-env notes](#pixi-env-notes).)
+      `sudo "$(command -v rlvm)" backup --config …` — see [pixi-env notes](#pixi-env-notes).)
 - [ ] Run any behavior-specific smoke tests for what changed this release
       (e.g. exit-code behavior, new flags).
 - [ ] Clean `main` checkout: `pixi run test` → all tests pass.
@@ -65,7 +65,7 @@ A reusable, version-agnostic guide for cutting a ResticLVM release. Replace
 ## Phase 4 — Post-release sanity
 
 - [ ] Fresh-install check: `pip install` the published wheel in a throwaway venv;
-      confirm version `X.Y.Z` and that `rlvm-backup`/`rlvm-prune` import.
+      confirm version `X.Y.Z` and that `rlvm backup`/`rlvm prune` import.
 - [ ] Confirm the GitHub release shows both artifacts and the correct `vX.Y.Z` tag.
 - [ ] If the README pins a "latest release" install tag, bump it to `vX.Y.Z`.
 
@@ -76,7 +76,7 @@ A reusable, version-agnostic guide for cutting a ResticLVM release. Replace
 Two gotchas when validating from an **editable pixi env** (they do **not** affect a
 real `pip install <wheel>` deployment):
 
-- **`rlvm-backup --version` lags after a bump.** The reported version comes from the
+- **`rlvm backup --version` lags after a bump.** The reported version comes from the
   package *metadata* snapshot written at install time, not from `pyproject.toml`. A
   `git pull` updates the code but not that snapshot, and **`pixi update` / `pixi
   install` won't refresh it either** (a version bump doesn't invalidate the lock for
@@ -86,6 +86,6 @@ real `pip install <wheel>` deployment):
   ```
   The running *code* is always current; only the printed number lags. So don't trust
   `--version` from an un-rebuilt editable env as a check that you're on new code.
-- **Running as root from the pixi env.** `sudo` resets `PATH`, so `sudo rlvm-backup`
-  may say "command not found" even though `rlvm-backup` works without `sudo`. Pin the
-  absolute path: `sudo "$(command -v rlvm-backup)" --config /path/to/config.toml`.
+- **Running as root from the pixi env.** `sudo` resets `PATH`, so `sudo rlvm backup`
+  may say "command not found" even though `rlvm backup` works without `sudo`. Pin the
+  absolute path: `sudo "$(command -v rlvm)" backup --config /path/to/config.toml`.


### PR DESCRIPTION
## Summary

- Replace `rlvm-backup` and `rlvm-prune` with a single `rlvm` command using argparse subparsers: `rlvm backup` and `rlvm prune`
- New `cli.py` module handles subcommand routing; runner modules expose `run(args)` functions
- Update all docs, tests, and references (README, CLAUDE.md, EXAMPLE_*.md, RELEASE_CHECKLIST, etc.)

## Migration

| Before | After |
|--------|-------|
| `sudo rlvm-backup --config ...` | `sudo rlvm backup --config ...` |
| `sudo rlvm-prune --config ...` | `sudo rlvm prune --config ...` |
| `rlvm-backup --version` | `rlvm --version` |

## Test plan

- [x] `pixi run test` — all 65 tests pass
- [x] `pixi run lint-sh` — no new shellcheck warnings
- [x] `rlvm --version`, `rlvm --help`, `rlvm backup --help`, `rlvm prune --help` all work without root
- [x] Old `rlvm-backup` / `rlvm-prune` commands no longer resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)