### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.0] — 2026-07-01
+
+### 🔌 API Changes
+- **Unified CLI.** The separate `rlvm-backup` and `rlvm-prune` commands are replaced
+  by a single `rlvm` command with subcommands: `rlvm backup` and `rlvm prune`.
+  **Action:** update cron jobs, systemd units, and scripts —
+  `sudo rlvm-backup --config …` becomes `sudo rlvm backup --config …`;
+  `sudo rlvm-prune --config …` becomes `sudo rlvm prune --config …`.
+
+### 🔧 Internal
+- New `resticlvm.orchestration.cli` module dispatches subcommands; the runner
+  modules expose `run(args)` for the CLI to call.
+- SSH agent helper scripts (`tools/ssh_setup/`) consolidated from five separate
+  scripts into a single `root-ssh-agent.sh` with subcommands (`start`, `stop`,
+  `status`, `ssh-add`). Key management delegates directly to `ssh-add`, so the
+  full `ssh-add` interface is available. These scripts are not part of the
+  installed package.
+
+### 📚 Documentation
+- Added `CLAUDE.md` for agent kickoff context.
+- SSH setup docs reframed: root SSH access is a prerequisite users can fulfill
+  however they prefer; the helper script is one option.
+- All docs, examples, and error messages updated for the `rlvm backup`/`rlvm prune`
+  syntax.
+
+### ⚠️ Known Limitations
+- A mid-run failure can still leak the LVM snapshot and bind-mounts (no cleanup trap
+  yet) — tracked in #24. Continue running ResticLVM **attended/manual only** until
+  that is fixed.
+- A repo failure within a multi-repo job stops backup to remaining repos in that
+  job — tracked in #46. Other jobs in the same run are unaffected.
+
+---
+
 ## [0.4.1] — 2026-06-23
 
 ### 📚 Documentation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Consistent backups of live Linux systems, using LVM snapshots and Restic.
 
+> **Note:** ResticLVM is an independent project, neither built by nor affiliated
+> with the [Restic](https://github.com/restic/restic) or
+> [LVM](https://sourceware.org/lvm2/) teams.
+
 ## Description
 
 ResticLVM is a Linux command-line tool that combines the snapshot features of Logical Volume Manager (LVM) with the data deduplication and encryption features of the [Restic](https://github.com/restic/restic) backup tool to create consistent, efficient backups of active systems, without taking the system offline.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A minimal end-to-end example that backs up the `/home` logical volume to a local
 
 ```bash
 # 1. Install
-pip install git+https://github.com/duanegoodner/resticlvm.git@v0.4.1
+pip install git+https://github.com/duanegoodner/resticlvm.git@v0.5.0
 
 # 2. Create a password file and initialize the Restic repository (one-time)
 sudo mkdir -p /root/.config/resticlvm/repo-creds
@@ -113,7 +113,7 @@ For the full configuration reference (multiple/remote/cloud repositories, `copy_
 Install the latest release directly from GitHub:
 
 ```bash
-pip install git+https://github.com/duanegoodner/resticlvm.git@v0.4.1
+pip install git+https://github.com/duanegoodner/resticlvm.git@v0.5.0
 ```
 
 This installs the CLI tools:
@@ -515,7 +515,7 @@ Snapshots tagged protected will automatically be preserved during pruning, regar
 Replace the version tag with any release from the [releases page](https://github.com/duanegoodner/resticlvm/releases):
 
 ```bash
-pip install git+https://github.com/duanegoodner/resticlvm.git@v0.4.1
+pip install git+https://github.com/duanegoodner/resticlvm.git@v0.5.0
 ```
 
 #### Install from Main Branch
@@ -531,19 +531,19 @@ pip install git+https://github.com/duanegoodner/resticlvm.git@main
 Install with B2 CLI support for Backblaze B2 management:
 
 ```bash
-pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.4.1#egg=resticlvm[b2]"
+pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.5.0#egg=resticlvm[b2]"
 ```
 
 Install with development tools (pytest):
 
 ```bash
-pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.4.1#egg=resticlvm[dev]"
+pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.5.0#egg=resticlvm[dev]"
 ```
 
 Install with both B2 and development dependencies:
 
 ```bash
-pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.4.1#egg=resticlvm[dev,b2]"
+pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.5.0#egg=resticlvm[dev,b2]"
 ```
 
 #### Clone and Install in Development Mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.4.1"
+version = "0.5.0"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump to 0.5.0 and CHANGELOG entry for the unified CLI release.

- Bump version in `pyproject.toml`
- Add `[0.5.0]` section to `CHANGELOG.md`
- Update install snippets in README from `@v0.4.1` to `@v0.5.0`

## Key changes in this release

- **Breaking:** `rlvm-backup`/`rlvm-prune` replaced by `rlvm backup`/`rlvm prune`
- SSH agent helper scripts consolidated into single `root-ssh-agent.sh`
- New issue #46 tracked in Known Limitations

Once merged, proceed with Phase 2 (build) and Phase 3 (tag + GitHub release).