### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.1] — 2026-07-01
+
+### 🐛 Bug Fixes
+- **`--dry-run` now works.** The flag was parsed by the CLI but never passed to the
+  shell scripts, so `rlvm backup --dry-run` performed a real backup. Fixed in both
+  the backup scripts and copy operations. (#48, #49)
+
+---
+
 ## [0.5.0] — 2026-07-01
 
 ### 🔌 API Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.5.0"
+version = "0.5.1"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 0.5.1 in `pyproject.toml`
- Add 0.5.1 section to `CHANGELOG.md`

Patch release for the `--dry-run` fix (#48, #49).

## Test plan

- [x] `pixi run test` — 67 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)