### PR TITLE
Add named prune policies and BackupConfig dataclass

### DIFF
--- a/src/resticlvm/orchestration/backup_config.py
+++ b/src/resticlvm/orchestration/backup_config.py
@@ -1,0 +1,140 @@
+"""Typed representation of a ResticLVM backup configuration file."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from resticlvm.orchestration.restic_repo import ResticPruneKeepParams
+
+
+def _parse_prune_policy(raw: dict) -> ResticPruneKeepParams:
+    return ResticPruneKeepParams(
+        last=int(raw["keep_last"]),
+        daily=int(raw["keep_daily"]),
+        weekly=int(raw["keep_weekly"]),
+        monthly=int(raw["keep_monthly"]),
+        yearly=int(raw["keep_yearly"]),
+    )
+
+
+@dataclass
+class CopyDestConfig:
+    """A copy-to destination for a repository."""
+
+    repo_path: str
+    password_file: Path
+    prune_keep_params: ResticPruneKeepParams
+
+
+@dataclass
+class RepoConfig:
+    """A single backup repository."""
+
+    repo_path: str
+    password_file: Path
+    prune_keep_params: ResticPruneKeepParams
+    copy_destinations: list[CopyDestConfig] = field(default_factory=list)
+
+
+@dataclass
+class StandardPathJobConfig:
+    """Config for a standard (non-LVM) backup job."""
+
+    backup_source_path: str
+    exclude_paths: list[str]
+    repositories: list[RepoConfig]
+
+
+@dataclass
+class LvJobConfig:
+    """Config for a logical-volume backup job."""
+
+    vg_name: str
+    lv_name: str
+    snapshot_size: str
+    backup_source_path: str
+    exclude_paths: list[str]
+    repositories: list[RepoConfig]
+
+
+@dataclass
+class BackupConfig:
+    """Typed, fully-resolved backup configuration."""
+
+    prune_policies: dict[str, ResticPruneKeepParams]
+    standard_paths: dict[str, StandardPathJobConfig]
+    logical_volume_roots: dict[str, LvJobConfig]
+    logical_volume_nonroots: dict[str, LvJobConfig]
+
+
+class BackupConfigFactory:
+    """Builds a BackupConfig from a raw config dict."""
+
+    def __init__(self, raw: dict):
+        self._raw = raw
+        self._policies = {
+            name: _parse_prune_policy(p)
+            for name, p in raw.get("prune_policy", {}).items()
+        }
+
+    def _resolve_prune_policy(self, repo_entry: dict) -> ResticPruneKeepParams:
+        name = repo_entry["prune_policy"]
+        if name not in self._policies:
+            raise ValueError(
+                f"Prune policy '{name}' not found in "
+                f"[prune_policy] section"
+            )
+        return self._policies[name]
+
+    def _parse_repos(self, job_raw: dict) -> list[RepoConfig]:
+        repos = []
+        for r in job_raw.get("repositories", []):
+            copy_dests = [
+                CopyDestConfig(
+                    repo_path=c["repo"],
+                    password_file=Path(c["password_file"]),
+                    prune_keep_params=self._resolve_prune_policy(c),
+                )
+                for c in r.get("copy_to", [])
+            ]
+            repos.append(RepoConfig(
+                repo_path=r["repo_path"],
+                password_file=Path(r["password_file"]),
+                prune_keep_params=self._resolve_prune_policy(r),
+                copy_destinations=copy_dests,
+            ))
+        return repos
+
+    def _parse_standard_paths(self) -> dict[str, StandardPathJobConfig]:
+        return {
+            name: StandardPathJobConfig(
+                backup_source_path=job["backup_source_path"],
+                exclude_paths=job.get("exclude_paths", []),
+                repositories=self._parse_repos(job),
+            )
+            for name, job in self._raw.get("standard_path", {}).items()
+        }
+
+    def _parse_lv_jobs(self, section_key: str) -> dict[str, LvJobConfig]:
+        return {
+            name: LvJobConfig(
+                vg_name=job["vg_name"],
+                lv_name=job["lv_name"],
+                snapshot_size=job["snapshot_size"],
+                backup_source_path=job["backup_source_path"],
+                exclude_paths=job.get("exclude_paths", []),
+                repositories=self._parse_repos(job),
+            )
+            for name, job in self._raw.get(section_key, {}).items()
+        }
+
+    def build(self) -> BackupConfig:
+        return BackupConfig(
+            prune_policies=self._policies,
+            standard_paths=self._parse_standard_paths(),
+            logical_volume_roots=self._parse_lv_jobs(
+                "logical_volume_root"
+            ),
+            logical_volume_nonroots=self._parse_lv_jobs(
+                "logical_volume_nonroot"
+            ),
+        )

--- a/src/resticlvm/orchestration/backup_plan.py
+++ b/src/resticlvm/orchestration/backup_plan.py
@@ -8,10 +8,11 @@ from pathlib import Path
 from resticlvm.orchestration.config_loader import load_config
 from resticlvm.orchestration.data_classes import BackupJob, TokenConfigKeyPair
 from resticlvm.orchestration.dispatch import RESOURCE_DISPATCH
+from resticlvm.orchestration.dispatch import RESOURCE_DISPATCH
 from resticlvm.orchestration.restic_repo import (
     ResticRepo,
-    ResticPruneKeepParams,
     CopyDestination,
+    resolve_prune_params,
 )
 
 
@@ -64,38 +65,25 @@ class BackupPlan:
                         copy_destinations.append(CopyDestination(
                             repo_path=copy_config["repo"],
                             password_file=Path(copy_config["password_file"]),
-                            prune_keep_params=ResticPruneKeepParams(
-                                last=int(copy_config["prune_keep_last"]),
-                                daily=int(copy_config["prune_keep_daily"]),
-                                weekly=int(copy_config["prune_keep_weekly"]),
-                                monthly=int(copy_config["prune_keep_monthly"]),
-                                yearly=int(copy_config["prune_keep_yearly"]),
+                            prune_keep_params=resolve_prune_params(
+                                copy_config, self.full_config
                             ),
                         ))
-                
+
                 repositories.append(ResticRepo(
                     repo_path=Path(repo_config["repo_path"]),
                     password_file=Path(repo_config["password_file"]),
-                    prune_keep_params=ResticPruneKeepParams(
-                        last=int(repo_config["prune_keep_last"]),
-                        daily=int(repo_config["prune_keep_daily"]),
-                        weekly=int(repo_config["prune_keep_weekly"]),
-                        monthly=int(repo_config["prune_keep_monthly"]),
-                        yearly=int(repo_config["prune_keep_yearly"]),
+                    prune_keep_params=resolve_prune_params(
+                        repo_config, self.full_config
                     ),
                     copy_destinations=copy_destinations,
                 ))
         else:
-            # Old format: single repo (backward compatibility)
             repositories.append(ResticRepo(
                 repo_path=Path(config["restic_repo"]),
                 password_file=Path(config["restic_password_file"]),
-                prune_keep_params=ResticPruneKeepParams(
-                    last=int(config["prune_keep_last"]),
-                    daily=int(config["prune_keep_daily"]),
-                    weekly=int(config["prune_keep_weekly"]),
-                    monthly=int(config["prune_keep_monthly"]),
-                    yearly=int(config["prune_keep_yearly"]),
+                prune_keep_params=resolve_prune_params(
+                    config, self.full_config
                 ),
             ))
 
@@ -120,6 +108,8 @@ class BackupPlan:
         """
         jobs = []
         for category, jobs_dict in self.full_config.items():
+            if category not in RESOURCE_DISPATCH:
+                continue
             for job_name in jobs_dict.keys():
                 jobs.append(self.create_backup_job(category, job_name))
         return jobs

--- a/src/resticlvm/orchestration/restic_repo.py
+++ b/src/resticlvm/orchestration/restic_repo.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from resticlvm import scripts
+from resticlvm.orchestration.dispatch import RESOURCE_DISPATCH
 
 
 @dataclass
@@ -22,6 +23,40 @@ class ResticPruneKeepParams:
     weekly: int
     monthly: int
     yearly: int
+
+
+def resolve_prune_params(
+    entry_config: dict,
+    full_config: dict,
+) -> ResticPruneKeepParams:
+    """Look up a named prune policy and return ResticPruneKeepParams.
+
+    Args:
+        entry_config: Per-repo or per-copy-destination config dict.
+            Must contain a ``prune_policy`` key naming a policy defined
+            in the top-level ``[prune_policy]`` section.
+        full_config: The entire parsed TOML config (for policy lookup).
+    """
+    if "prune_policy" not in entry_config:
+        raise ValueError(
+            "Repository config must include a prune_policy reference"
+        )
+
+    policy_name = entry_config["prune_policy"]
+    policies = full_config.get("prune_policy", {})
+    if policy_name not in policies:
+        raise ValueError(
+            f"Prune policy '{policy_name}' not found in "
+            f"[prune_policy] section"
+        )
+    p = policies[policy_name]
+    return ResticPruneKeepParams(
+        last=int(p["keep_last"]),
+        daily=int(p["keep_daily"]),
+        weekly=int(p["keep_weekly"]),
+        monthly=int(p["keep_monthly"]),
+        yearly=int(p["keep_yearly"]),
+    )
 
 
 @dataclass
@@ -112,13 +147,13 @@ def confirm_unique_repos(config: dict) -> dict[tuple[str, str], list[ResticRepo]
     seen_repos = {}
 
     for category in config.keys():
+        if category not in RESOURCE_DISPATCH:
+            continue
         for job_name, job_config in config[category].items():
             repos_for_job = []
             repo_paths_in_job = set()
 
-            # Handle both old (single repo) and new (repo array) formats
             if "repositories" in job_config:
-                # New format: array of repositories
                 for repo_config in job_config["repositories"]:
                     repo_path = repo_config["repo_path"]
                     if repo_path in repo_paths_in_job:
@@ -130,26 +165,17 @@ def confirm_unique_repos(config: dict) -> dict[tuple[str, str], list[ResticRepo]
                     repos_for_job.append(ResticRepo(
                         repo_path=Path(repo_path),
                         password_file=Path(repo_config["password_file"]),
-                        prune_keep_params=ResticPruneKeepParams(
-                            last=int(repo_config["prune_keep_last"]),
-                            daily=int(repo_config["prune_keep_daily"]),
-                            weekly=int(repo_config["prune_keep_weekly"]),
-                            monthly=int(repo_config["prune_keep_monthly"]),
-                            yearly=int(repo_config["prune_keep_yearly"]),
+                        prune_keep_params=resolve_prune_params(
+                            repo_config, config
                         ),
                     ))
             else:
-                # Old format: single repo (backward compatibility)
                 repo_path = job_config["restic_repo"]
                 repos_for_job.append(ResticRepo(
                     repo_path=Path(repo_path),
                     password_file=Path(job_config["restic_password_file"]),
-                    prune_keep_params=ResticPruneKeepParams(
-                        last=int(job_config["prune_keep_last"]),
-                        daily=int(job_config["prune_keep_daily"]),
-                        weekly=int(job_config["prune_keep_weekly"]),
-                        monthly=int(job_config["prune_keep_monthly"]),
-                        yearly=int(job_config["prune_keep_yearly"]),
+                    prune_keep_params=resolve_prune_params(
+                        job_config, config
                     ),
                 ))
 

--- a/test/test_backup_config.py
+++ b/test/test_backup_config.py
@@ -1,0 +1,287 @@
+"""Tests for the backup_config module."""
+
+import pytest
+
+from resticlvm.orchestration.backup_config import (
+    BackupConfig,
+    BackupConfigFactory,
+    CopyDestConfig,
+    LvJobConfig,
+    RepoConfig,
+    StandardPathJobConfig,
+)
+from resticlvm.orchestration.restic_repo import ResticPruneKeepParams
+
+
+STANDARD_POLICY = {
+    "keep_last": 10,
+    "keep_daily": 7,
+    "keep_weekly": 4,
+    "keep_monthly": 6,
+    "keep_yearly": 1,
+}
+
+STANDARD_PARAMS = ResticPruneKeepParams(
+    last=10, daily=7, weekly=4, monthly=6, yearly=1
+)
+
+
+def _minimal_config():
+    """A small but complete raw config dict."""
+    return {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "standard_path": {
+            "boot": {
+                "backup_source_path": "/boot",
+                "exclude_paths": [],
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/boot",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    }
+                ],
+            }
+        },
+    }
+
+
+def test_from_dict_parses_prune_policies():
+    cfg = BackupConfigFactory(_minimal_config()).build()
+    assert "standard" in cfg.prune_policies
+    assert cfg.prune_policies["standard"] == STANDARD_PARAMS
+
+
+def test_from_dict_parses_standard_path():
+    cfg = BackupConfigFactory(_minimal_config()).build()
+    assert "boot" in cfg.standard_paths
+    job = cfg.standard_paths["boot"]
+    assert isinstance(job, StandardPathJobConfig)
+    assert job.backup_source_path == "/boot"
+    assert job.exclude_paths == []
+    assert len(job.repositories) == 1
+
+    repo = job.repositories[0]
+    assert isinstance(repo, RepoConfig)
+    assert repo.repo_path == "/srv/backup/boot"
+    assert repo.prune_keep_params == STANDARD_PARAMS
+
+
+def test_from_dict_parses_logical_volume_root():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "logical_volume_root": {
+            "root": {
+                "vg_name": "vg0",
+                "lv_name": "lv_root",
+                "snapshot_size": "30G",
+                "backup_source_path": "/",
+                "exclude_paths": ["/dev", "/proc"],
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/root",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    }
+                ],
+            }
+        },
+    }
+    cfg = BackupConfigFactory(raw).build()
+    job = cfg.logical_volume_roots["root"]
+    assert isinstance(job, LvJobConfig)
+    assert job.vg_name == "vg0"
+    assert job.lv_name == "lv_root"
+    assert job.snapshot_size == "30G"
+    assert job.exclude_paths == ["/dev", "/proc"]
+    assert job.repositories[0].prune_keep_params == STANDARD_PARAMS
+
+
+def test_from_dict_parses_logical_volume_nonroot():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "logical_volume_nonroot": {
+            "data": {
+                "vg_name": "vg_storage",
+                "lv_name": "lv_data",
+                "snapshot_size": "10G",
+                "backup_source_path": "/data",
+                "exclude_paths": [],
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/data",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    }
+                ],
+            }
+        },
+    }
+    cfg = BackupConfigFactory(raw).build()
+    assert "data" in cfg.logical_volume_nonroots
+    assert cfg.logical_volume_nonroots["data"].vg_name == "vg_storage"
+
+
+def test_from_dict_multiple_policies():
+    raw = {
+        "prune_policy": {
+            "frequent": {
+                "keep_last": 20,
+                "keep_daily": 14,
+                "keep_weekly": 8,
+                "keep_monthly": 12,
+                "keep_yearly": 3,
+            },
+            "archival": {
+                "keep_last": 3,
+                "keep_daily": 1,
+                "keep_weekly": 1,
+                "keep_monthly": 12,
+                "keep_yearly": 10,
+            },
+        },
+        "standard_path": {
+            "boot": {
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/srv/local/boot",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "frequent",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/boot",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "archival",
+                    },
+                ],
+            }
+        },
+    }
+    cfg = BackupConfigFactory(raw).build()
+    repos = cfg.standard_paths["boot"].repositories
+    assert repos[0].prune_keep_params.last == 20
+    assert repos[1].prune_keep_params.last == 3
+    assert repos[1].prune_keep_params.yearly == 10
+
+
+def test_from_dict_with_copy_destinations():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "standard_path": {
+            "boot": {
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/boot",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                        "copy_to": [
+                            {
+                                "repo": "sftp:host:/backup/boot",
+                                "password_file": "/tmp/remote_pw.txt",
+                                "prune_policy": "standard",
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+    }
+    cfg = BackupConfigFactory(raw).build()
+    repo = cfg.standard_paths["boot"].repositories[0]
+    assert len(repo.copy_destinations) == 1
+
+    dest = repo.copy_destinations[0]
+    assert isinstance(dest, CopyDestConfig)
+    assert dest.repo_path == "sftp:host:/backup/boot"
+    assert dest.prune_keep_params == STANDARD_PARAMS
+
+
+def test_from_dict_missing_policy_raises():
+    raw = {
+        "standard_path": {
+            "boot": {
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/boot",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "nonexistent",
+                    }
+                ],
+            }
+        },
+    }
+    with pytest.raises(ValueError, match="not found"):
+        BackupConfigFactory(raw).build()
+
+
+def test_from_dict_empty_config():
+    cfg = BackupConfigFactory({}).build()
+    assert cfg.prune_policies == {}
+    assert cfg.standard_paths == {}
+    assert cfg.logical_volume_roots == {}
+    assert cfg.logical_volume_nonroots == {}
+
+
+def test_from_dict_empty_categories():
+    raw = {"prune_policy": {"standard": STANDARD_POLICY}}
+    cfg = BackupConfigFactory(raw).build()
+    assert cfg.standard_paths == {}
+    assert cfg.logical_volume_roots == {}
+    assert cfg.logical_volume_nonroots == {}
+
+
+def test_from_dict_multiple_repos_per_job():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "standard_path": {
+            "boot": {
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/srv/local/boot",
+                        "password_file": "/tmp/pw1.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/boot",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "s3:bucket/boot",
+                        "password_file": "/tmp/pw3.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            }
+        },
+    }
+    cfg = BackupConfigFactory(raw).build()
+    repos = cfg.standard_paths["boot"].repositories
+    assert len(repos) == 3
+    assert repos[0].repo_path == "/srv/local/boot"
+    assert repos[1].repo_path == "sftp:host:/backup/boot"
+    assert repos[2].repo_path == "s3:bucket/boot"
+
+
+def test_from_dict_exclude_paths_defaults_to_empty():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "standard_path": {
+            "boot": {
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/boot",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    }
+                ],
+            }
+        },
+    }
+    cfg = BackupConfigFactory(raw).build()
+    assert cfg.standard_paths["boot"].exclude_paths == []

--- a/test/test_backup_plan.py
+++ b/test/test_backup_plan.py
@@ -13,6 +13,20 @@ from resticlvm.orchestration.data_classes import BackupJob
 def temp_config_file():
     """Create a temporary config file for testing."""
     toml_content = """
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
+[prune_policy.light]
+keep_last = 5
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
 [logical_volume_root.root]
 vg_name = "vg0"
 lv_name = "lv_root"
@@ -21,22 +35,14 @@ restic_repo = "/srv/backup/root"
 restic_password_file = "/tmp/password.txt"
 backup_source_path = "/"
 exclude_paths = ["/dev", "/proc", "/sys"]
-prune_keep_last = 10
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 6
-prune_keep_yearly = 1
+prune_policy = "standard"
 
 [standard_path.boot]
 backup_source_path = "/boot"
 restic_repo = "/srv/backup/boot"
 restic_password_file = "/tmp/password.txt"
 exclude_paths = []
-prune_keep_last = 5
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 6
-prune_keep_yearly = 1
+prune_policy = "light"
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
         f.write(toml_content)
@@ -134,17 +140,19 @@ def test_backup_plan_backup_jobs_empty_config():
 def test_backup_plan_single_job_config():
     """Test BackupPlan with a config containing only one job."""
     toml_content = """
+[prune_policy.minimal]
+keep_last = 3
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
 [standard_path.home]
 backup_source_path = "/home"
 restic_repo = "/backup/home"
 restic_password_file = "/tmp/pass.txt"
 exclude_paths = [".cache"]
-
-prune_keep_last = 3
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 6
-prune_keep_yearly = 1
+prune_policy = "minimal"
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
         f.write(toml_content)
@@ -153,9 +161,127 @@ prune_keep_yearly = 1
     try:
         plan = BackupPlan(config_path=temp_path)
         jobs = plan.backup_jobs
-        
+
         assert len(jobs) == 1
         assert jobs[0].category == "standard_path"
         assert jobs[0].name == "home"
     finally:
         temp_path.unlink()
+
+
+def test_backup_plan_with_prune_policy():
+    """Repos referencing a named prune policy resolve correctly."""
+    toml_content = """
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
+[standard_path.boot]
+backup_source_path = "/boot"
+exclude_paths = []
+
+[[standard_path.boot.repositories]]
+repo_path = "/srv/backup/boot"
+password_file = "/tmp/password.txt"
+prune_policy = "standard"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(toml_content)
+        temp_path = Path(f.name)
+
+    try:
+        plan = BackupPlan(config_path=temp_path)
+        jobs = plan.backup_jobs
+
+        assert len(jobs) == 1
+        repo = jobs[0].repositories[0]
+        assert repo.prune_keep_params.last == 10
+        assert repo.prune_keep_params.daily == 7
+        assert repo.prune_keep_params.yearly == 1
+    finally:
+        temp_path.unlink()
+
+
+def test_backup_plan_prune_policy_skipped_in_jobs_list():
+    """The prune_policy section does not produce a backup job."""
+    toml_content = """
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
+[logical_volume_root.root]
+vg_name = "vg0"
+lv_name = "lv_root"
+snapshot_size = "2G"
+backup_source_path = "/"
+exclude_paths = []
+
+[[logical_volume_root.root.repositories]]
+repo_path = "/srv/backup/root"
+password_file = "/tmp/password.txt"
+prune_policy = "standard"
+
+[standard_path.boot]
+backup_source_path = "/boot"
+exclude_paths = []
+
+[[standard_path.boot.repositories]]
+repo_path = "/srv/backup/boot"
+password_file = "/tmp/password.txt"
+prune_policy = "standard"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(toml_content)
+        temp_path = Path(f.name)
+
+    try:
+        plan = BackupPlan(config_path=temp_path)
+        jobs = plan.backup_jobs
+
+        assert len(jobs) == 2
+        categories = {j.category for j in jobs}
+        assert "prune_policy" not in categories
+    finally:
+        temp_path.unlink()
+
+
+def test_backup_plan_invalid_prune_policy_reference():
+    """Referencing a nonexistent prune policy raises ValueError."""
+    toml_content = """
+[standard_path.boot]
+backup_source_path = "/boot"
+exclude_paths = []
+
+[[standard_path.boot.repositories]]
+repo_path = "/srv/backup/boot"
+password_file = "/tmp/password.txt"
+prune_policy = "nonexistent"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(toml_content)
+        temp_path = Path(f.name)
+
+    try:
+        plan = BackupPlan(config_path=temp_path)
+        with pytest.raises(ValueError, match="not found"):
+            plan.backup_jobs
+    finally:
+        temp_path.unlink()
+
+
+def test_backup_plan_old_single_repo_format_with_policy(temp_config_file):
+    """Old single-repo format works when prune_policy is used."""
+    plan = BackupPlan(config_path=temp_config_file)
+    jobs = plan.backup_jobs
+
+    root_job = next(j for j in jobs if j.name == "root")
+    assert root_job.repositories[0].prune_keep_params.last == 10
+
+    boot_job = next(j for j in jobs if j.name == "boot")
+    assert boot_job.repositories[0].prune_keep_params.last == 5

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -11,6 +11,13 @@ from resticlvm.orchestration.config_loader import load_config
 def test_load_config_success():
     """Test loading a valid TOML configuration file."""
     toml_content = """
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
 [logical_volume_root.root]
 vg_name = "vg0"
 lv_name = "lv_root"
@@ -19,11 +26,7 @@ restic_repo = "/srv/backup/test"
 restic_password_file = "/tmp/password.txt"
 backup_source_path = "/"
 exclude_paths = ["/dev", "/proc"]
-prune_keep_last = 10
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 6
-prune_keep_yearly = 1
+prune_policy = "standard"
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
         f.write(toml_content)
@@ -69,17 +72,19 @@ invalid syntax here
 def test_load_config_with_path_string():
     """Test loading config with a string path instead of Path object."""
     toml_content = """
+[prune_policy.light]
+keep_last = 5
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
 [standard_path.boot]
 backup_source_path = "/boot"
 restic_repo = "/backup/boot"
 restic_password_file = "/tmp/pass.txt"
 exclude_paths = []
-
-prune_keep_last = 5
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 6
-prune_keep_yearly = 1
+prune_policy = "light"
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
         f.write(toml_content)

--- a/test/test_restic_repo.py
+++ b/test/test_restic_repo.py
@@ -8,6 +8,7 @@ from resticlvm.orchestration.restic_repo import (
     ResticPruneKeepParams,
     ResticRepo,
     confirm_unique_repos,
+    resolve_prune_params,
 )
 
 
@@ -38,29 +39,69 @@ def test_restic_repo_creation():
     assert repo.prune_keep_params == prune_params
 
 
+# ─── resolve_prune_params ──────────────────────────────────────────────────
+
+
+def test_resolve_prune_params_named_policy():
+    """A prune_policy reference resolves from the full config."""
+    entry = {"prune_policy": "standard"}
+    full_config = {
+        "prune_policy": {
+            "standard": {
+                "keep_last": 5,
+                "keep_daily": 3,
+                "keep_weekly": 2,
+                "keep_monthly": 1,
+                "keep_yearly": 0,
+            }
+        }
+    }
+    params = resolve_prune_params(entry, full_config)
+    assert params == ResticPruneKeepParams(
+        last=5, daily=3, weekly=2, monthly=1, yearly=0
+    )
+
+
+def test_resolve_prune_params_missing_policy_raises():
+    """Referencing a nonexistent policy name is an error."""
+    entry = {"prune_policy": "nonexistent"}
+    with pytest.raises(ValueError, match="not found"):
+        resolve_prune_params(entry, {})
+
+
+def test_resolve_prune_params_no_policy_raises():
+    """Missing prune_policy key is an error."""
+    with pytest.raises(ValueError, match="must include"):
+        resolve_prune_params({}, {})
+
+
+# ─── confirm_unique_repos ─────────────────────────────────────────────────
+
+
 def test_confirm_unique_repos_success():
     """Test that unique repositories are accepted."""
     config = {
+        "prune_policy": {
+            "standard": {
+                "keep_last": 10,
+                "keep_daily": 7,
+                "keep_weekly": 4,
+                "keep_monthly": 6,
+                "keep_yearly": 1,
+            },
+        },
         "logical_volume_root": {
             "root": {
                 "restic_repo": "/srv/backup/root",
                 "restic_password_file": "/tmp/pass1.txt",
-                "prune_keep_last": 10,
-                "prune_keep_daily": 7,
-                "prune_keep_weekly": 4,
-                "prune_keep_monthly": 6,
-                "prune_keep_yearly": 1,
+                "prune_policy": "standard",
             }
         },
         "standard_path": {
             "boot": {
                 "restic_repo": "/srv/backup/boot",
                 "restic_password_file": "/tmp/pass2.txt",
-                "prune_keep_last": 5,
-                "prune_keep_daily": 7,
-                "prune_keep_weekly": 4,
-                "prune_keep_monthly": 6,
-                "prune_keep_yearly": 1,
+                "prune_policy": "standard",
             }
         },
     }
@@ -69,7 +110,7 @@ def test_confirm_unique_repos_success():
     assert len(repos) == 2
     assert ("logical_volume_root", "root") in repos
     assert ("standard_path", "boot") in repos
-    
+
     root_repos = repos[("logical_volume_root", "root")]
     assert isinstance(root_repos, list)
     assert len(root_repos) == 1
@@ -81,26 +122,27 @@ def test_confirm_unique_repos_success():
 def test_confirm_unique_repos_duplicate_fails():
     """Test that duplicate repository paths within the same job raise ValueError."""
     config = {
+        "prune_policy": {
+            "standard": {
+                "keep_last": 10,
+                "keep_daily": 7,
+                "keep_weekly": 4,
+                "keep_monthly": 6,
+                "keep_yearly": 1,
+            },
+        },
         "logical_volume_root": {
             "root": {
                 "repositories": [
                     {
                         "repo_path": "/srv/backup/duplicate",
                         "password_file": "/tmp/pass1.txt",
-                        "prune_keep_last": 10,
-                        "prune_keep_daily": 7,
-                        "prune_keep_weekly": 4,
-                        "prune_keep_monthly": 6,
-                        "prune_keep_yearly": 1,
+                        "prune_policy": "standard",
                     },
                     {
-                        "repo_path": "/srv/backup/duplicate",  # Duplicate within same job!
+                        "repo_path": "/srv/backup/duplicate",
                         "password_file": "/tmp/pass2.txt",
-                        "prune_keep_last": 5,
-                        "prune_keep_daily": 7,
-                        "prune_keep_weekly": 4,
-                        "prune_keep_monthly": 6,
-                        "prune_keep_yearly": 1,
+                        "prune_policy": "standard",
                     },
                 ]
             }
@@ -114,15 +156,20 @@ def test_confirm_unique_repos_duplicate_fails():
 def test_confirm_unique_repos_single_job():
     """Test confirm_unique_repos with a single job."""
     config = {
+        "prune_policy": {
+            "standard": {
+                "keep_last": 10,
+                "keep_daily": 7,
+                "keep_weekly": 4,
+                "keep_monthly": 6,
+                "keep_yearly": 1,
+            },
+        },
         "logical_volume_root": {
             "root": {
                 "restic_repo": "/srv/backup/root",
                 "restic_password_file": "/tmp/pass.txt",
-                "prune_keep_last": 10,
-                "prune_keep_daily": 7,
-                "prune_keep_weekly": 4,
-                "prune_keep_monthly": 6,
-                "prune_keep_yearly": 1,
+                "prune_policy": "standard",
             }
         }
     }
@@ -130,3 +177,66 @@ def test_confirm_unique_repos_single_job():
     repos = confirm_unique_repos(config)
     assert len(repos) == 1
     assert ("logical_volume_root", "root") in repos
+
+
+def test_confirm_unique_repos_skips_prune_policy_key():
+    """The prune_policy top-level key is skipped, not treated as a category."""
+    config = {
+        "prune_policy": {
+            "standard": {
+                "keep_last": 10,
+                "keep_daily": 7,
+                "keep_weekly": 4,
+                "keep_monthly": 6,
+                "keep_yearly": 1,
+            }
+        },
+        "standard_path": {
+            "boot": {
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/boot",
+                        "password_file": "/tmp/pass.txt",
+                        "prune_policy": "standard",
+                    }
+                ]
+            }
+        },
+    }
+
+    repos = confirm_unique_repos(config)
+    assert len(repos) == 1
+    assert ("standard_path", "boot") in repos
+    assert repos[("standard_path", "boot")][0].prune_keep_params.last == 10
+
+
+def test_confirm_unique_repos_with_named_policy():
+    """Repos using prune_policy references resolve correctly."""
+    config = {
+        "prune_policy": {
+            "archival": {
+                "keep_last": 3,
+                "keep_daily": 1,
+                "keep_weekly": 1,
+                "keep_monthly": 12,
+                "keep_yearly": 5,
+            }
+        },
+        "logical_volume_root": {
+            "root": {
+                "repositories": [
+                    {
+                        "repo_path": "/srv/backup/root",
+                        "password_file": "/tmp/pass.txt",
+                        "prune_policy": "archival",
+                    }
+                ]
+            }
+        },
+    }
+
+    repos = confirm_unique_repos(config)
+    params = repos[("logical_volume_root", "root")][0].prune_keep_params
+    assert params.last == 3
+    assert params.monthly == 12
+    assert params.yearly == 5


### PR DESCRIPTION
## Summary

- Replace inline `prune_keep_*` keys on each repository with named `[prune_policy.<name>]` sections referenced by `prune_policy = "<name>"`
- Add `resolve_prune_params()` in `restic_repo.py` for policy lookup (used by `BackupPlan` and `confirm_unique_repos`)
- Add `BackupConfig` dataclass and `BackupConfigFactory` for typed, fully-resolved config representation (standalone — not yet wired into `BackupPlan`)
- Filter `backup_jobs` and `confirm_unique_repos` iteration via `RESOURCE_DISPATCH` allowlist so `prune_policy` top-level key is skipped
- All test configs updated to use named policies

## Test plan

- [x] `pixi run test` — 87 tests pass (11 new for `BackupConfig`, existing tests updated)
- [ ] Next: wire `BackupConfig` into `BackupPlan` to flatten `create_backup_job`

🤖 Generated with [Claude Code](https://claude.com/claude-code)