### PR TITLE
Flatten config to [volume.<name>] with VolumeType enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,25 @@ sudo restic init --repo /srv/backup/home \
 
 # 3. Write a config (backup.toml), adjusting vg_name/lv_name to your system
 cat > backup.toml <<'EOF'
-[logical_volume_nonroot.home]
+[prune_policy.standard]
+keep_last = 7
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 3
+keep_yearly = 1
+
+[volume.home]
+volume_type = "lv_nonroot"
 vg_name = "vg0"
 lv_name = "lv_home"
 snapshot_size = "2G"
 backup_source_path = "/home"
 exclude_paths = []
 
-  [[logical_volume_nonroot.home.repositories]]
+  [[volume.home.repositories]]
   repo_path = "/srv/backup/home"
   password_file = "/root/.config/resticlvm/repo-creds/home.txt"
-  prune_keep_last = 7
-  prune_keep_daily = 7
-  prune_keep_weekly = 4
-  prune_keep_monthly = 3
-  prune_keep_yearly = 1
+  prune_policy = "standard"
 EOF
 
 # 4. Preview, then run (must be root)
@@ -165,179 +169,141 @@ This example demonstrates **four backup destinations** per volume using a combin
 4. **Direct B2 cloud**: Direct backup to offsite cloud storage
 
 ```toml
+# Named prune policies — define once, reference by name in each repository
+[prune_policy.local]
+keep_last = 7
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 3
+keep_yearly = 1
+
+[prune_policy.remote]
+keep_last = 30
+keep_daily = 30
+keep_weekly = 12
+keep_monthly = 12
+keep_yearly = 3
+
+[prune_policy.cloud]
+keep_last = 14
+keep_daily = 14
+keep_weekly = 8
+keep_monthly = 6
+keep_yearly = 2
+
 # /boot/efi partition (EFI System Partition)
-[standard_path.boot-efi]
+[volume.boot-efi]
+volume_type = "standard_path"
 backup_source_path = "/boot/efi"
 exclude_paths = []
 
-  [[standard_path.boot-efi.repositories]]
+  [[volume.boot-efi.repositories]]
   repo_path = "/path/to/boot-efi-repo"
   password_file = "/path/to/boot-efi-repo-password.txt"
-  prune_keep_last = 7
-  prune_keep_daily = 7
-  prune_keep_weekly = 4
-  prune_keep_monthly = 3
-  prune_keep_yearly = 1
+  prune_policy = "local"
 
     # Optional: Copy to another repo after local backup completes
-    [[standard_path.boot-efi.repositories.copy_to]]
+    [[volume.boot-efi.repositories.copy_to]]
     repo = "sftp:backupuser@backup.example.com:/backups/hostname/boot-efi-copy"
     password_file = "/path/to/boot-efi-repo-password.txt"
-    prune_keep_last = 30
-    prune_keep_daily = 30
-    prune_keep_weekly = 12
-    prune_keep_monthly = 12
-    prune_keep_yearly = 3
+    prune_policy = "remote"
 
-  [[standard_path.boot-efi.repositories]]
+  [[volume.boot-efi.repositories]]
   repo_path = "sftp:backupuser@backup.example.com:/backups/hostname/boot-efi"
   password_file = "/path/to/boot-efi-repo-password.txt"
-  prune_keep_last = 30
-  prune_keep_daily = 30
-  prune_keep_weekly = 12
-  prune_keep_monthly = 12
-  prune_keep_yearly = 3
+  prune_policy = "remote"
 
-  [[standard_path.boot-efi.repositories]]
+  [[volume.boot-efi.repositories]]
   repo_path = "s3:s3.us-west-004.backblazeb2.com/bucket-name/hostname/boot-efi"
   password_file = "/path/to/boot-efi-repo-password.txt"
-  prune_keep_last = 14
-  prune_keep_daily = 14
-  prune_keep_weekly = 8
-  prune_keep_monthly = 6
-  prune_keep_yearly = 2
+  prune_policy = "cloud"
 
 # /boot partition (kernel and initramfs)
-[standard_path.boot]
+[volume.boot]
+volume_type = "standard_path"
 backup_source_path = "/boot"
 exclude_paths = []
 
-  [[standard_path.boot.repositories]]
+  [[volume.boot.repositories]]
   repo_path = "/path/to/boot-repo"
   password_file = "/path/to/boot-repo-password.txt"
-  prune_keep_last = 7
-  prune_keep_daily = 7
-  prune_keep_weekly = 4
-  prune_keep_monthly = 3
-  prune_keep_yearly = 1
+  prune_policy = "local"
 
     # Optional: Copy to another repo after local backup completes
-    [[standard_path.boot.repositories.copy_to]]
+    [[volume.boot.repositories.copy_to]]
     repo = "sftp:backupuser@backup.example.com:/backups/hostname/boot-copy"
     password_file = "/path/to/boot-repo-password.txt"
-    prune_keep_last = 30
-    prune_keep_daily = 30
-    prune_keep_weekly = 12
-    prune_keep_monthly = 12
-    prune_keep_yearly = 3
+    prune_policy = "remote"
 
-  [[standard_path.boot.repositories]]
+  [[volume.boot.repositories]]
   repo_path = "sftp:backupuser@backup.example.com:/backups/hostname/boot"
   password_file = "/path/to/boot-repo-password.txt"
-  prune_keep_last = 30
-  prune_keep_daily = 30
-  prune_keep_weekly = 12
-  prune_keep_monthly = 12
-  prune_keep_yearly = 3
+  prune_policy = "remote"
 
-  [[standard_path.boot.repositories]]
+  [[volume.boot.repositories]]
   repo_path = "s3:s3.us-west-004.backblazeb2.com/bucket-name/hostname/boot"
   password_file = "/path/to/boot-repo-password.txt"
-  prune_keep_last = 14
-  prune_keep_daily = 14
-  prune_keep_weekly = 8
-  prune_keep_monthly = 6
-  prune_keep_yearly = 2
+  prune_policy = "cloud"
 
 # Root filesystem (LVM logical volume mounted at /)
-[logical_volume_root.root]
+[volume.root]
+volume_type = "lv_root"
 vg_name = "vg0"
 lv_name = "lv_root"
 snapshot_size = "2G"
 backup_source_path = "/"
 exclude_paths = ["/dev", "/proc", "/sys", "/tmp", "/var/tmp", "/run"]
 
-  [[logical_volume_root.root.repositories]]
+  [[volume.root.repositories]]
   repo_path = "/path/to/root-repo"
   password_file = "/path/to/root-repo-password.txt"
-  prune_keep_last = 7
-  prune_keep_daily = 7
-  prune_keep_weekly = 4
-  prune_keep_monthly = 3
-  prune_keep_yearly = 1
+  prune_policy = "local"
 
     # Optional: Copy to another repo after local backup completes
-    [[logical_volume_root.root.repositories.copy_to]]
+    [[volume.root.repositories.copy_to]]
     repo = "sftp:backupuser@backup.example.com:/backups/hostname/root-copy"
     password_file = "/path/to/root-repo-password.txt"
-    prune_keep_last = 30
-    prune_keep_daily = 30
-    prune_keep_weekly = 12
-    prune_keep_monthly = 12
-    prune_keep_yearly = 3
+    prune_policy = "remote"
 
-  [[logical_volume_root.root.repositories]]
+  [[volume.root.repositories]]
   repo_path = "sftp:backupuser@backup.example.com:/backups/hostname/root"
   password_file = "/path/to/root-repo-password.txt"
-  prune_keep_last = 30
-  prune_keep_daily = 30
-  prune_keep_weekly = 12
-  prune_keep_monthly = 12
-  prune_keep_yearly = 3
+  prune_policy = "remote"
 
-  [[logical_volume_root.root.repositories]]
+  [[volume.root.repositories]]
   repo_path = "s3:s3.us-west-004.backblazeb2.com/bucket-name/hostname/root"
   password_file = "/path/to/root-repo-password.txt"
-  prune_keep_last = 14
-  prune_keep_daily = 14
-  prune_keep_weekly = 8
-  prune_keep_monthly = 6
-  prune_keep_yearly = 2
+  prune_policy = "cloud"
 
 # /home filesystem (LVM logical volume mounted elsewhere)
-[logical_volume_nonroot.home]
+[volume.home]
+volume_type = "lv_nonroot"
 vg_name = "vg0"
 lv_name = "lv_home"
 snapshot_size = "2G"
 backup_source_path = "/home"
 exclude_paths = []
 
-  [[logical_volume_nonroot.home.repositories]]
+  [[volume.home.repositories]]
   repo_path = "/path/to/home-repo"
   password_file = "/path/to/home-repo-password.txt"
-  prune_keep_last = 7
-  prune_keep_daily = 7
-  prune_keep_weekly = 4
-  prune_keep_monthly = 3
-  prune_keep_yearly = 1
+  prune_policy = "local"
 
     # Optional: Copy to another repo after local backup completes
-    [[logical_volume_nonroot.home.repositories.copy_to]]
+    [[volume.home.repositories.copy_to]]
     repo = "sftp:backupuser@backup.example.com:/backups/hostname/home-copy"
     password_file = "/path/to/home-repo-password.txt"
-    prune_keep_last = 30
-    prune_keep_daily = 30
-    prune_keep_weekly = 12
-    prune_keep_monthly = 12
-    prune_keep_yearly = 3
+    prune_policy = "remote"
 
-  [[logical_volume_nonroot.home.repositories]]
+  [[volume.home.repositories]]
   repo_path = "sftp:backupuser@backup.example.com:/backups/hostname/home"
   password_file = "/path/to/home-repo-password.txt"
-  prune_keep_last = 30
-  prune_keep_daily = 30
-  prune_keep_weekly = 12
-  prune_keep_monthly = 12
-  prune_keep_yearly = 3
+  prune_policy = "remote"
 
-  [[logical_volume_nonroot.home.repositories]]
+  [[volume.home.repositories]]
   repo_path = "s3:s3.us-west-004.backblazeb2.com/bucket-name/hostname/home"
   password_file = "/path/to/home-repo-password.txt"
-  prune_keep_last = 14
-  prune_keep_daily = 14
-  prune_keep_weekly = 8
-  prune_keep_monthly = 6
-  prune_keep_yearly = 2
+  prune_policy = "cloud"
 ```
 
 ### Running
@@ -365,34 +331,42 @@ See [below](#running-specific-jobs-from-config-file) for running specific (not a
 ResticLVM configuration files use TOML format with the following hierarchical structure:
 
 ```toml
-[<volume_type>.<volume_id>]
+[prune_policy.<policy_name>]
+keep_last = 7
+# ... other retention settings ...
+
+[volume.<volume_id>]
+volume_type = "standard_path"  # or "lv_root" / "lv_nonroot"
 backup_source_path = "/path/to/source"
 # ... other volume-specific settings ...
 
-  [[<volume_type>.<volume_id>.repositories]]
+  [[volume.<volume_id>.repositories]]
   repo_path = "/path/to/local-repo"
   password_file = "/path/to/password.txt"
-  # ... prune settings ...
+  prune_policy = "<policy_name>"
 
-    [[<volume_type>.<volume_id>.repositories.copy_to]]
+    [[volume.<volume_id>.repositories.copy_to]]
     repo = "sftp:user@host:/remote/repo"
     password_file = "/path/to/password.txt"
-    # ... independent prune settings ...
+    prune_policy = "<policy_name>"
 ```
 
 **Structure components:**
 
-- **`[<volume_type>.<volume_id>]`**: Top-level section defining the volume to back up
-  - `<volume_type>` specifies the type of volume:
-    - `standard_path`: Standard filesystem path (e.g., `/boot`, `/boot/efi`)
-    - `logical_volume_root`: LVM logical volume mounted at `/`
-    - `logical_volume_nonroot`: LVM logical volume mounted elsewhere (e.g., `/home`, `/data`)
-  - `<volume_id>` is your chosen identifier for that specific volume (any valid name without spaces)
+- **`[prune_policy.<policy_name>]`**: Named retention policy (define once, reference by name)
+  - `keep_last`, `keep_daily`, `keep_weekly`, `keep_monthly`, `keep_yearly`
 
-- **`[[<volume_type>.<volume_id>.repositories]]`**: Direct backup destination (can have multiple)
+- **`[volume.<volume_id>]`**: Top-level section defining the volume to back up
+  - `<volume_id>` is your chosen identifier for that specific volume
+  - `volume_type` specifies the type of volume:
+    - `standard_path`: Standard filesystem path (e.g., `/boot`, `/boot/efi`)
+    - `lv_root`: LVM logical volume mounted at `/`
+    - `lv_nonroot`: LVM logical volume mounted elsewhere (e.g., `/home`, `/data`)
+
+- **`[[volume.<volume_id>.repositories]]`**: Direct backup destination (can have multiple)
   - Defines where to send backups directly from the source
 
-- **`[[<volume_type>.<volume_id>.repositories.copy_to]]`**: Copy destination (can have multiple per repository)
+- **`[[volume.<volume_id>.repositories.copy_to]]`**: Copy destination (can have multiple per repository)
   - Copies snapshots from the parent repository after backup completes
 
 
@@ -401,11 +375,11 @@ backup_source_path = "/path/to/source"
 The `--category` and/or `--name` options can be used if we only want to run some (not all) of the backup jobs specified in a .toml file.
 
 ```
-# Run all jobs in a category
+# Run only standard_path volumes
 sudo rlvm backup --config /path/to/resticlvm_config.toml --category standard_path
 
-# Run a single specific job
-sudo rlvm backup --config /path/to/resticlvm_config.toml --category standard_path --name boot
+# Run a single specific volume
+sudo rlvm backup --config /path/to/resticlvm_config.toml --name boot
 ```
 
 ### Data Transfer Methods
@@ -479,7 +453,7 @@ See [Restic documentation](https://restic.readthedocs.io/en/stable/030_preparing
 ```bash
 sudo rlvm prune --config /path/to/your/resticlvm_config.toml
 ```
-- Applies the configured prune_keep_* settings to each Restic repo.
+- Applies the configured prune policy settings to each Restic repo.
 
 - Handles Restic's `forget` and `--prune` commands.
 
@@ -487,11 +461,11 @@ sudo rlvm prune --config /path/to/your/resticlvm_config.toml
 
 We can also choose to prune only certain repos:
 ```
-# Prune by category
-sudo rlvm prune --config /path/to/resticlvm_config.toml --category logical_volume_root
+# Prune only lv_root volumes
+sudo rlvm prune --config /path/to/resticlvm_config.toml --category lv_root
 
-# Prune by specific job name
-sudo rlvm prune --config /path/to/resticlvm_config.toml --category logical_volume_root --name lv_root
+# Prune a specific volume by name
+sudo rlvm prune --config /path/to/resticlvm_config.toml --name root
 ```
 
 #### Protecting Specific Snapshots from Deletion

--- a/src/resticlvm/orchestration/backup_config.py
+++ b/src/resticlvm/orchestration/backup_config.py
@@ -1,6 +1,7 @@
 """Typed representation of a ResticLVM backup configuration file."""
 
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 
 from resticlvm.orchestration.restic_repo import ResticPruneKeepParams
@@ -14,6 +15,12 @@ def _parse_prune_policy(raw: dict) -> ResticPruneKeepParams:
         monthly=int(raw["keep_monthly"]),
         yearly=int(raw["keep_yearly"]),
     )
+
+
+class VolumeType(Enum):
+    STANDARD_PATH = "standard_path"
+    LV_ROOT = "lv_root"
+    LV_NONROOT = "lv_nonroot"
 
 
 @dataclass
@@ -36,24 +43,16 @@ class RepoConfig:
 
 
 @dataclass
-class StandardPathJobConfig:
-    """Config for a standard (non-LVM) backup job."""
+class VolumeConfig:
+    """Config for a backup volume."""
 
+    volume_type: VolumeType
     backup_source_path: str
     exclude_paths: list[str]
     repositories: list[RepoConfig]
-
-
-@dataclass
-class LvJobConfig:
-    """Config for a logical-volume backup job."""
-
-    vg_name: str
-    lv_name: str
-    snapshot_size: str
-    backup_source_path: str
-    exclude_paths: list[str]
-    repositories: list[RepoConfig]
+    vg_name: str | None = None
+    lv_name: str | None = None
+    snapshot_size: str | None = None
 
 
 @dataclass
@@ -61,9 +60,7 @@ class BackupConfig:
     """Typed, fully-resolved backup configuration."""
 
     prune_policies: dict[str, ResticPruneKeepParams]
-    standard_paths: dict[str, StandardPathJobConfig]
-    logical_volume_roots: dict[str, LvJobConfig]
-    logical_volume_nonroots: dict[str, LvJobConfig]
+    volumes: dict[str, VolumeConfig]
 
 
 class BackupConfigFactory:
@@ -104,37 +101,32 @@ class BackupConfigFactory:
             ))
         return repos
 
-    def _parse_standard_paths(self) -> dict[str, StandardPathJobConfig]:
-        return {
-            name: StandardPathJobConfig(
-                backup_source_path=job["backup_source_path"],
-                exclude_paths=job.get("exclude_paths", []),
-                repositories=self._parse_repos(job),
-            )
-            for name, job in self._raw.get("standard_path", {}).items()
-        }
+    def _parse_volumes(self) -> dict[str, VolumeConfig]:
+        volumes = {}
+        for name, job in self._raw.get("volume", {}).items():
+            volume_type = VolumeType(job["volume_type"])
 
-    def _parse_lv_jobs(self, section_key: str) -> dict[str, LvJobConfig]:
-        return {
-            name: LvJobConfig(
-                vg_name=job["vg_name"],
-                lv_name=job["lv_name"],
-                snapshot_size=job["snapshot_size"],
+            vg_name = None
+            lv_name = None
+            snapshot_size = None
+            if volume_type in (VolumeType.LV_ROOT, VolumeType.LV_NONROOT):
+                vg_name = job["vg_name"]
+                lv_name = job["lv_name"]
+                snapshot_size = job["snapshot_size"]
+
+            volumes[name] = VolumeConfig(
+                volume_type=volume_type,
                 backup_source_path=job["backup_source_path"],
                 exclude_paths=job.get("exclude_paths", []),
                 repositories=self._parse_repos(job),
+                vg_name=vg_name,
+                lv_name=lv_name,
+                snapshot_size=snapshot_size,
             )
-            for name, job in self._raw.get(section_key, {}).items()
-        }
+        return volumes
 
     def build(self) -> BackupConfig:
         return BackupConfig(
             prune_policies=self._policies,
-            standard_paths=self._parse_standard_paths(),
-            logical_volume_roots=self._parse_lv_jobs(
-                "logical_volume_root"
-            ),
-            logical_volume_nonroots=self._parse_lv_jobs(
-                "logical_volume_nonroot"
-            ),
+            volumes=self._parse_volumes(),
         )

--- a/src/resticlvm/orchestration/backup_plan.py
+++ b/src/resticlvm/orchestration/backup_plan.py
@@ -4,14 +4,12 @@ and creates executable backup job instances based on it.
 """
 
 from pathlib import Path
-from typing import Union
 
 from resticlvm.orchestration.backup_config import (
-    BackupConfig,
     BackupConfigFactory,
-    LvJobConfig,
     RepoConfig,
-    StandardPathJobConfig,
+    VolumeConfig,
+    VolumeType,
 )
 from resticlvm.orchestration.config_loader import load_config
 from resticlvm.orchestration.data_classes import BackupJob, TokenConfigKeyPair
@@ -20,8 +18,6 @@ from resticlvm.orchestration.restic_repo import (
     CopyDestination,
     ResticRepo,
 )
-
-JobConfig = Union[StandardPathJobConfig, LvJobConfig]
 
 
 def _to_restic_repo(repo_cfg: RepoConfig) -> ResticRepo:
@@ -40,16 +36,16 @@ def _to_restic_repo(repo_cfg: RepoConfig) -> ResticRepo:
     )
 
 
-def _job_config_dict(job_cfg: JobConfig) -> dict:
+def _job_config_dict(vol_cfg: VolumeConfig) -> dict:
     """Build the dict that BackupJob uses for shell script arg building."""
     d = {
-        "backup_source_path": job_cfg.backup_source_path,
-        "exclude_paths": job_cfg.exclude_paths,
+        "backup_source_path": vol_cfg.backup_source_path,
+        "exclude_paths": vol_cfg.exclude_paths,
     }
-    if isinstance(job_cfg, LvJobConfig):
-        d["vg_name"] = job_cfg.vg_name
-        d["lv_name"] = job_cfg.lv_name
-        d["snapshot_size"] = job_cfg.snapshot_size
+    if vol_cfg.volume_type in (VolumeType.LV_ROOT, VolumeType.LV_NONROOT):
+        d["vg_name"] = vol_cfg.vg_name
+        d["lv_name"] = vol_cfg.lv_name
+        d["snapshot_size"] = vol_cfg.snapshot_size
     return d
 
 
@@ -63,32 +59,24 @@ class BackupPlan:
         self._config = BackupConfigFactory(raw).build()
 
     def _build_backup_job(
-        self, category: str, name: str, job_cfg: JobConfig
+        self, name: str, vol_cfg: VolumeConfig
     ) -> BackupJob:
-        dispatch = RESOURCE_DISPATCH[category]
+        dispatch = RESOURCE_DISPATCH[vol_cfg.volume_type]
         return BackupJob(
             script_name=dispatch["script_name"],
             script_token_config_key_pairs=TokenConfigKeyPair.from_token_key_map(
                 dispatch["token_key_map"]
             ),
-            config=_job_config_dict(job_cfg),
+            config=_job_config_dict(vol_cfg),
             name=name,
-            category=category,
-            repositories=[_to_restic_repo(r) for r in job_cfg.repositories],
+            category=vol_cfg.volume_type.value,
+            repositories=[_to_restic_repo(r) for r in vol_cfg.repositories],
             dry_run=self.dry_run,
         )
 
     @property
     def backup_jobs(self) -> list[BackupJob]:
-        jobs = []
-        for name, cfg in self._config.standard_paths.items():
-            jobs.append(self._build_backup_job("standard_path", name, cfg))
-        for name, cfg in self._config.logical_volume_roots.items():
-            jobs.append(
-                self._build_backup_job("logical_volume_root", name, cfg)
-            )
-        for name, cfg in self._config.logical_volume_nonroots.items():
-            jobs.append(
-                self._build_backup_job("logical_volume_nonroot", name, cfg)
-            )
-        return jobs
+        return [
+            self._build_backup_job(name, cfg)
+            for name, cfg in self._config.volumes.items()
+        ]

--- a/src/resticlvm/orchestration/dispatch.py
+++ b/src/resticlvm/orchestration/dispatch.py
@@ -4,10 +4,10 @@ Defines token-to-config key mappings and script dispatch tables
 for ResticLVM backup jobs.
 """
 
+from resticlvm.orchestration.backup_config import VolumeType
+
 # Mapping of CLI tokens to configuration keys for standard path backups.
 STANDARD_PATH_TOKEN_KEY_MAP = {
-    "-r": "restic_repo",
-    "-p": "restic_password_file",
     "-s": "backup_source_path",
     "-e": "exclude_paths",
 }
@@ -17,24 +17,22 @@ LOGICAL_VOLUME_TOKEN_KEY_MAP = {
     "-g": "vg_name",
     "-l": "lv_name",
     "-z": "snapshot_size",
-    "-r": "restic_repo",
-    "-p": "restic_password_file",
     "-s": "backup_source_path",
     "-e": "exclude_paths",
 }
 
-# Dispatch table mapping backup categories to their corresponding
+# Dispatch table mapping volume types to their corresponding
 # script names and token-key mappings.
 RESOURCE_DISPATCH = {
-    "standard_path": {
+    VolumeType.STANDARD_PATH: {
         "script_name": "backup_path.sh",
         "token_key_map": STANDARD_PATH_TOKEN_KEY_MAP,
     },
-    "logical_volume_root": {
+    VolumeType.LV_ROOT: {
         "script_name": "backup_lv_root.sh",
         "token_key_map": LOGICAL_VOLUME_TOKEN_KEY_MAP,
     },
-    "logical_volume_nonroot": {
+    VolumeType.LV_NONROOT: {
         "script_name": "backup_lv_nonroot.sh",
         "token_key_map": LOGICAL_VOLUME_TOKEN_KEY_MAP,
     },

--- a/src/resticlvm/orchestration/prune_runner.py
+++ b/src/resticlvm/orchestration/prune_runner.py
@@ -25,21 +25,14 @@ def run(args):
     raw = load_config(config_path)
     config = BackupConfigFactory(raw).build()
 
-    _SECTIONS = [
-        ("standard_path", config.standard_paths),
-        ("logical_volume_root", config.logical_volume_roots),
-        ("logical_volume_nonroot", config.logical_volume_nonroots),
-    ]
-
-    for category, jobs in _SECTIONS:
-        if args.category and category != args.category:
+    for name, vol_cfg in config.volumes.items():
+        if args.category and vol_cfg.volume_type.value != args.category:
             continue
-        for name, job_cfg in jobs.items():
-            if args.name and name != args.name:
-                continue
-            for repo_cfg in job_cfg.repositories:
-                repo = _to_restic_repo(repo_cfg)
-                repo.prune(dry_run=args.dry_run)
+        if args.name and name != args.name:
+            continue
+        for repo_cfg in vol_cfg.repositories:
+            repo = _to_restic_repo(repo_cfg)
+            repo.prune(dry_run=args.dry_run)
 
 
 def main():
@@ -63,17 +56,15 @@ def main():
     parser.add_argument(
         "--category",
         type=str,
-        help="Only prune repos in this backup category.",
+        help="Only prune repos with this volume type.",
     )
     parser.add_argument(
         "--name",
         type=str,
-        help="Only prune the repo matching this backup job name.",
+        help="Only prune the repo matching this volume name.",
     )
     args = parser.parse_args()
 
-    # Root check happens after argument parsing so --version / --help work
-    # without elevation.
     ensure_running_as_root()
 
     run(args)

--- a/test/test_backup_config.py
+++ b/test/test_backup_config.py
@@ -6,9 +6,9 @@ from resticlvm.orchestration.backup_config import (
     BackupConfig,
     BackupConfigFactory,
     CopyDestConfig,
-    LvJobConfig,
     RepoConfig,
-    StandardPathJobConfig,
+    VolumeConfig,
+    VolumeType,
 )
 from resticlvm.orchestration.restic_repo import ResticPruneKeepParams
 
@@ -30,8 +30,9 @@ def _minimal_config():
     """A small but complete raw config dict."""
     return {
         "prune_policy": {"standard": STANDARD_POLICY},
-        "standard_path": {
+        "volume": {
             "boot": {
+                "volume_type": "standard_path",
                 "backup_source_path": "/boot",
                 "exclude_paths": [],
                 "repositories": [
@@ -46,32 +47,35 @@ def _minimal_config():
     }
 
 
-def test_from_dict_parses_prune_policies():
+def test_parses_prune_policies():
     cfg = BackupConfigFactory(_minimal_config()).build()
     assert "standard" in cfg.prune_policies
     assert cfg.prune_policies["standard"] == STANDARD_PARAMS
 
 
-def test_from_dict_parses_standard_path():
+def test_parses_standard_path_volume():
     cfg = BackupConfigFactory(_minimal_config()).build()
-    assert "boot" in cfg.standard_paths
-    job = cfg.standard_paths["boot"]
-    assert isinstance(job, StandardPathJobConfig)
-    assert job.backup_source_path == "/boot"
-    assert job.exclude_paths == []
-    assert len(job.repositories) == 1
+    assert "boot" in cfg.volumes
+    vol = cfg.volumes["boot"]
+    assert isinstance(vol, VolumeConfig)
+    assert vol.volume_type == VolumeType.STANDARD_PATH
+    assert vol.backup_source_path == "/boot"
+    assert vol.exclude_paths == []
+    assert vol.vg_name is None
+    assert len(vol.repositories) == 1
 
-    repo = job.repositories[0]
+    repo = vol.repositories[0]
     assert isinstance(repo, RepoConfig)
     assert repo.repo_path == "/srv/backup/boot"
     assert repo.prune_keep_params == STANDARD_PARAMS
 
 
-def test_from_dict_parses_logical_volume_root():
+def test_parses_lv_root_volume():
     raw = {
         "prune_policy": {"standard": STANDARD_POLICY},
-        "logical_volume_root": {
+        "volume": {
             "root": {
+                "volume_type": "lv_root",
                 "vg_name": "vg0",
                 "lv_name": "lv_root",
                 "snapshot_size": "30G",
@@ -88,20 +92,21 @@ def test_from_dict_parses_logical_volume_root():
         },
     }
     cfg = BackupConfigFactory(raw).build()
-    job = cfg.logical_volume_roots["root"]
-    assert isinstance(job, LvJobConfig)
-    assert job.vg_name == "vg0"
-    assert job.lv_name == "lv_root"
-    assert job.snapshot_size == "30G"
-    assert job.exclude_paths == ["/dev", "/proc"]
-    assert job.repositories[0].prune_keep_params == STANDARD_PARAMS
+    vol = cfg.volumes["root"]
+    assert vol.volume_type == VolumeType.LV_ROOT
+    assert vol.vg_name == "vg0"
+    assert vol.lv_name == "lv_root"
+    assert vol.snapshot_size == "30G"
+    assert vol.exclude_paths == ["/dev", "/proc"]
+    assert vol.repositories[0].prune_keep_params == STANDARD_PARAMS
 
 
-def test_from_dict_parses_logical_volume_nonroot():
+def test_parses_lv_nonroot_volume():
     raw = {
         "prune_policy": {"standard": STANDARD_POLICY},
-        "logical_volume_nonroot": {
+        "volume": {
             "data": {
+                "volume_type": "lv_nonroot",
                 "vg_name": "vg_storage",
                 "lv_name": "lv_data",
                 "snapshot_size": "10G",
@@ -118,11 +123,12 @@ def test_from_dict_parses_logical_volume_nonroot():
         },
     }
     cfg = BackupConfigFactory(raw).build()
-    assert "data" in cfg.logical_volume_nonroots
-    assert cfg.logical_volume_nonroots["data"].vg_name == "vg_storage"
+    assert "data" in cfg.volumes
+    assert cfg.volumes["data"].volume_type == VolumeType.LV_NONROOT
+    assert cfg.volumes["data"].vg_name == "vg_storage"
 
 
-def test_from_dict_multiple_policies():
+def test_multiple_policies():
     raw = {
         "prune_policy": {
             "frequent": {
@@ -140,8 +146,9 @@ def test_from_dict_multiple_policies():
                 "keep_yearly": 10,
             },
         },
-        "standard_path": {
+        "volume": {
             "boot": {
+                "volume_type": "standard_path",
                 "backup_source_path": "/boot",
                 "repositories": [
                     {
@@ -159,17 +166,18 @@ def test_from_dict_multiple_policies():
         },
     }
     cfg = BackupConfigFactory(raw).build()
-    repos = cfg.standard_paths["boot"].repositories
+    repos = cfg.volumes["boot"].repositories
     assert repos[0].prune_keep_params.last == 20
     assert repos[1].prune_keep_params.last == 3
     assert repos[1].prune_keep_params.yearly == 10
 
 
-def test_from_dict_with_copy_destinations():
+def test_copy_destinations():
     raw = {
         "prune_policy": {"standard": STANDARD_POLICY},
-        "standard_path": {
+        "volume": {
             "boot": {
+                "volume_type": "standard_path",
                 "backup_source_path": "/boot",
                 "repositories": [
                     {
@@ -189,7 +197,7 @@ def test_from_dict_with_copy_destinations():
         },
     }
     cfg = BackupConfigFactory(raw).build()
-    repo = cfg.standard_paths["boot"].repositories[0]
+    repo = cfg.volumes["boot"].repositories[0]
     assert len(repo.copy_destinations) == 1
 
     dest = repo.copy_destinations[0]
@@ -198,10 +206,11 @@ def test_from_dict_with_copy_destinations():
     assert dest.prune_keep_params == STANDARD_PARAMS
 
 
-def test_from_dict_missing_policy_raises():
+def test_missing_policy_raises():
     raw = {
-        "standard_path": {
+        "volume": {
             "boot": {
+                "volume_type": "standard_path",
                 "backup_source_path": "/boot",
                 "repositories": [
                     {
@@ -217,27 +226,38 @@ def test_from_dict_missing_policy_raises():
         BackupConfigFactory(raw).build()
 
 
-def test_from_dict_empty_config():
+def test_invalid_volume_type_raises():
+    raw = {
+        "volume": {
+            "boot": {
+                "volume_type": "invalid",
+                "backup_source_path": "/boot",
+                "repositories": [],
+            }
+        },
+    }
+    with pytest.raises(ValueError):
+        BackupConfigFactory(raw).build()
+
+
+def test_empty_config():
     cfg = BackupConfigFactory({}).build()
     assert cfg.prune_policies == {}
-    assert cfg.standard_paths == {}
-    assert cfg.logical_volume_roots == {}
-    assert cfg.logical_volume_nonroots == {}
+    assert cfg.volumes == {}
 
 
-def test_from_dict_empty_categories():
+def test_no_volumes():
     raw = {"prune_policy": {"standard": STANDARD_POLICY}}
     cfg = BackupConfigFactory(raw).build()
-    assert cfg.standard_paths == {}
-    assert cfg.logical_volume_roots == {}
-    assert cfg.logical_volume_nonroots == {}
+    assert cfg.volumes == {}
 
 
-def test_from_dict_multiple_repos_per_job():
+def test_multiple_repos_per_volume():
     raw = {
         "prune_policy": {"standard": STANDARD_POLICY},
-        "standard_path": {
+        "volume": {
             "boot": {
+                "volume_type": "standard_path",
                 "backup_source_path": "/boot",
                 "repositories": [
                     {
@@ -260,18 +280,19 @@ def test_from_dict_multiple_repos_per_job():
         },
     }
     cfg = BackupConfigFactory(raw).build()
-    repos = cfg.standard_paths["boot"].repositories
+    repos = cfg.volumes["boot"].repositories
     assert len(repos) == 3
     assert repos[0].repo_path == "/srv/local/boot"
     assert repos[1].repo_path == "sftp:host:/backup/boot"
     assert repos[2].repo_path == "s3:bucket/boot"
 
 
-def test_from_dict_exclude_paths_defaults_to_empty():
+def test_exclude_paths_defaults_to_empty():
     raw = {
         "prune_policy": {"standard": STANDARD_POLICY},
-        "standard_path": {
+        "volume": {
             "boot": {
+                "volume_type": "standard_path",
                 "backup_source_path": "/boot",
                 "repositories": [
                     {
@@ -284,4 +305,4 @@ def test_from_dict_exclude_paths_defaults_to_empty():
         },
     }
     cfg = BackupConfigFactory(raw).build()
-    assert cfg.standard_paths["boot"].exclude_paths == []
+    assert cfg.volumes["boot"].exclude_paths == []

--- a/test/test_backup_plan.py
+++ b/test/test_backup_plan.py
@@ -28,23 +28,25 @@ keep_weekly = 4
 keep_monthly = 6
 keep_yearly = 1
 
-[logical_volume_root.root]
+[volume.root]
+volume_type = "lv_root"
 vg_name = "vg0"
 lv_name = "lv_root"
 snapshot_size = "2G"
 backup_source_path = "/"
 exclude_paths = ["/dev", "/proc", "/sys"]
 
-[[logical_volume_root.root.repositories]]
+[[volume.root.repositories]]
 repo_path = "/srv/backup/root"
 password_file = "/tmp/password.txt"
 prune_policy = "standard"
 
-[standard_path.boot]
+[volume.boot]
+volume_type = "standard_path"
 backup_source_path = "/boot"
 exclude_paths = []
 
-[[standard_path.boot.repositories]]
+[[volume.boot.repositories]]
 repo_path = "/srv/backup/boot"
 password_file = "/tmp/password.txt"
 prune_policy = "light"
@@ -72,14 +74,14 @@ def test_backup_plan_dry_run_mode(temp_config_file):
     assert plan.dry_run is True
 
 
-def test_backup_plan_job_logical_volume(temp_config_file):
-    """Test that a logical_volume_root job is built correctly."""
+def test_backup_plan_job_lv_root(temp_config_file):
+    """Test that an lv_root job is built correctly."""
     plan = BackupPlan(config_path=temp_config_file)
     jobs = plan.backup_jobs
 
     job = next(j for j in jobs if j.name == "root")
     assert isinstance(job, BackupJob)
-    assert job.category == "logical_volume_root"
+    assert job.category == "lv_root"
     assert job.script_name == "backup_lv_root.sh"
     assert job.config["vg_name"] == "vg0"
     assert job.config["lv_name"] == "lv_root"
@@ -107,7 +109,7 @@ def test_backup_plan_backup_jobs_property(temp_config_file):
     assert all(isinstance(job, BackupJob) for job in jobs)
 
     job_identifiers = {(job.category, job.name) for job in jobs}
-    assert ("logical_volume_root", "root") in job_identifiers
+    assert ("lv_root", "root") in job_identifiers
     assert ("standard_path", "boot") in job_identifiers
 
 
@@ -137,11 +139,12 @@ keep_weekly = 4
 keep_monthly = 6
 keep_yearly = 1
 
-[standard_path.home]
+[volume.home]
+volume_type = "standard_path"
 backup_source_path = "/home"
 exclude_paths = [".cache"]
 
-[[standard_path.home.repositories]]
+[[volume.home.repositories]]
 repo_path = "/backup/home"
 password_file = "/tmp/pass.txt"
 prune_policy = "minimal"
@@ -171,11 +174,12 @@ keep_weekly = 4
 keep_monthly = 6
 keep_yearly = 1
 
-[standard_path.boot]
+[volume.boot]
+volume_type = "standard_path"
 backup_source_path = "/boot"
 exclude_paths = []
 
-[[standard_path.boot.repositories]]
+[[volume.boot.repositories]]
 repo_path = "/srv/backup/boot"
 password_file = "/tmp/password.txt"
 prune_policy = "standard"
@@ -197,60 +201,15 @@ prune_policy = "standard"
         temp_path.unlink()
 
 
-def test_backup_plan_prune_policy_not_in_jobs():
-    """The prune_policy section does not produce a backup job."""
-    toml_content = """
-[prune_policy.standard]
-keep_last = 10
-keep_daily = 7
-keep_weekly = 4
-keep_monthly = 6
-keep_yearly = 1
-
-[logical_volume_root.root]
-vg_name = "vg0"
-lv_name = "lv_root"
-snapshot_size = "2G"
-backup_source_path = "/"
-exclude_paths = []
-
-[[logical_volume_root.root.repositories]]
-repo_path = "/srv/backup/root"
-password_file = "/tmp/password.txt"
-prune_policy = "standard"
-
-[standard_path.boot]
-backup_source_path = "/boot"
-exclude_paths = []
-
-[[standard_path.boot.repositories]]
-repo_path = "/srv/backup/boot"
-password_file = "/tmp/password.txt"
-prune_policy = "standard"
-"""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
-        f.write(toml_content)
-        temp_path = Path(f.name)
-
-    try:
-        plan = BackupPlan(config_path=temp_path)
-        jobs = plan.backup_jobs
-
-        assert len(jobs) == 2
-        categories = {j.category for j in jobs}
-        assert "prune_policy" not in categories
-    finally:
-        temp_path.unlink()
-
-
 def test_backup_plan_invalid_prune_policy_reference():
     """Referencing a nonexistent prune policy raises ValueError at init."""
     toml_content = """
-[standard_path.boot]
+[volume.boot]
+volume_type = "standard_path"
 backup_source_path = "/boot"
 exclude_paths = []
 
-[[standard_path.boot.repositories]]
+[[volume.boot.repositories]]
 repo_path = "/srv/backup/boot"
 password_file = "/tmp/password.txt"
 prune_policy = "nonexistent"

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -18,14 +18,17 @@ keep_weekly = 4
 keep_monthly = 6
 keep_yearly = 1
 
-[logical_volume_root.root]
+[volume.root]
+volume_type = "lv_root"
 vg_name = "vg0"
 lv_name = "lv_root"
 snapshot_size = "2G"
-restic_repo = "/srv/backup/test"
-restic_password_file = "/tmp/password.txt"
 backup_source_path = "/"
 exclude_paths = ["/dev", "/proc"]
+
+[[volume.root.repositories]]
+repo_path = "/srv/backup/test"
+password_file = "/tmp/password.txt"
 prune_policy = "standard"
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
@@ -35,11 +38,11 @@ prune_policy = "standard"
     try:
         config = load_config(temp_path)
         assert isinstance(config, dict)
-        assert "logical_volume_root" in config
-        assert "root" in config["logical_volume_root"]
-        assert config["logical_volume_root"]["root"]["vg_name"] == "vg0"
-        assert config["logical_volume_root"]["root"]["snapshot_size"] == "2G"
-        assert config["logical_volume_root"]["root"]["exclude_paths"] == ["/dev", "/proc"]
+        assert "volume" in config
+        assert "root" in config["volume"]
+        assert config["volume"]["root"]["vg_name"] == "vg0"
+        assert config["volume"]["root"]["snapshot_size"] == "2G"
+        assert config["volume"]["root"]["exclude_paths"] == ["/dev", "/proc"]
     finally:
         temp_path.unlink()
 
@@ -53,7 +56,7 @@ def test_load_config_file_not_found():
 def test_load_config_invalid_toml():
     """Test that TOMLDecodeError is raised for invalid TOML syntax."""
     import tomllib
-    
+
     invalid_toml = """
 [section
 invalid syntax here
@@ -79,11 +82,14 @@ keep_weekly = 4
 keep_monthly = 6
 keep_yearly = 1
 
-[standard_path.boot]
+[volume.boot]
+volume_type = "standard_path"
 backup_source_path = "/boot"
-restic_repo = "/backup/boot"
-restic_password_file = "/tmp/pass.txt"
 exclude_paths = []
+
+[[volume.boot.repositories]]
+repo_path = "/backup/boot"
+password_file = "/tmp/pass.txt"
 prune_policy = "light"
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
@@ -91,8 +97,8 @@ prune_policy = "light"
         temp_path = f.name
 
     try:
-        config = load_config(temp_path)  # Pass as string, not Path
+        config = load_config(temp_path)
         assert isinstance(config, dict)
-        assert "standard_path" in config
+        assert "volume" in config
     finally:
         Path(temp_path).unlink()

--- a/test/test_data_classes.py
+++ b/test/test_data_classes.py
@@ -137,7 +137,7 @@ def test_backup_job_get_arg_entry_int():
         script_token_config_key_pairs=[pair],
         config=config,
         name="test",
-        category="logical_volume_root",
+        category="lv_root",
         repositories=[],
     )
     

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -1,5 +1,6 @@
 """Tests for the dispatch module."""
 
+from resticlvm.orchestration.backup_config import VolumeType
 from resticlvm.orchestration.dispatch import (
     LOGICAL_VOLUME_TOKEN_KEY_MAP,
     RESOURCE_DISPATCH,
@@ -9,8 +10,6 @@ from resticlvm.orchestration.dispatch import (
 
 def test_standard_path_token_key_map():
     """Test STANDARD_PATH_TOKEN_KEY_MAP has expected mappings."""
-    assert STANDARD_PATH_TOKEN_KEY_MAP["-r"] == "restic_repo"
-    assert STANDARD_PATH_TOKEN_KEY_MAP["-p"] == "restic_password_file"
     assert STANDARD_PATH_TOKEN_KEY_MAP["-s"] == "backup_source_path"
     assert STANDARD_PATH_TOKEN_KEY_MAP["-e"] == "exclude_paths"
 
@@ -20,42 +19,39 @@ def test_logical_volume_token_key_map():
     assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-g"] == "vg_name"
     assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-l"] == "lv_name"
     assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-z"] == "snapshot_size"
-    assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-r"] == "restic_repo"
-    assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-p"] == "restic_password_file"
     assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-s"] == "backup_source_path"
     assert LOGICAL_VOLUME_TOKEN_KEY_MAP["-e"] == "exclude_paths"
 
 
 def test_resource_dispatch_structure():
     """Test RESOURCE_DISPATCH has expected structure."""
-    assert "standard_path" in RESOURCE_DISPATCH
-    assert "logical_volume_root" in RESOURCE_DISPATCH
-    assert "logical_volume_nonroot" in RESOURCE_DISPATCH
+    assert VolumeType.STANDARD_PATH in RESOURCE_DISPATCH
+    assert VolumeType.LV_ROOT in RESOURCE_DISPATCH
+    assert VolumeType.LV_NONROOT in RESOURCE_DISPATCH
 
 
 def test_resource_dispatch_standard_path():
     """Test RESOURCE_DISPATCH standard_path configuration."""
-    standard_path = RESOURCE_DISPATCH["standard_path"]
-    assert standard_path["script_name"] == "backup_path.sh"
-    assert standard_path["token_key_map"] == STANDARD_PATH_TOKEN_KEY_MAP
+    entry = RESOURCE_DISPATCH[VolumeType.STANDARD_PATH]
+    assert entry["script_name"] == "backup_path.sh"
+    assert entry["token_key_map"] == STANDARD_PATH_TOKEN_KEY_MAP
 
 
-def test_resource_dispatch_logical_volume_root():
-    """Test RESOURCE_DISPATCH logical_volume_root configuration."""
-    lv_root = RESOURCE_DISPATCH["logical_volume_root"]
-    assert lv_root["script_name"] == "backup_lv_root.sh"
-    assert lv_root["token_key_map"] == LOGICAL_VOLUME_TOKEN_KEY_MAP
+def test_resource_dispatch_lv_root():
+    """Test RESOURCE_DISPATCH lv_root configuration."""
+    entry = RESOURCE_DISPATCH[VolumeType.LV_ROOT]
+    assert entry["script_name"] == "backup_lv_root.sh"
+    assert entry["token_key_map"] == LOGICAL_VOLUME_TOKEN_KEY_MAP
 
 
-def test_resource_dispatch_logical_volume_nonroot():
-    """Test RESOURCE_DISPATCH logical_volume_nonroot configuration."""
-    lv_nonroot = RESOURCE_DISPATCH["logical_volume_nonroot"]
-    assert lv_nonroot["script_name"] == "backup_lv_nonroot.sh"
-    assert lv_nonroot["token_key_map"] == LOGICAL_VOLUME_TOKEN_KEY_MAP
+def test_resource_dispatch_lv_nonroot():
+    """Test RESOURCE_DISPATCH lv_nonroot configuration."""
+    entry = RESOURCE_DISPATCH[VolumeType.LV_NONROOT]
+    assert entry["script_name"] == "backup_lv_nonroot.sh"
+    assert entry["token_key_map"] == LOGICAL_VOLUME_TOKEN_KEY_MAP
 
 
 def test_resource_dispatch_keys_count():
-    """Test that RESOURCE_DISPATCH has exactly the expected categories."""
+    """Test that RESOURCE_DISPATCH has exactly the expected volume types."""
     assert len(RESOURCE_DISPATCH) == 3
-    expected_keys = {"standard_path", "logical_volume_root", "logical_volume_nonroot"}
-    assert set(RESOURCE_DISPATCH.keys()) == expected_keys
+    assert set(RESOURCE_DISPATCH.keys()) == set(VolumeType)


### PR DESCRIPTION
## Summary

- Replace three top-level category sections (`standard_path`, `logical_volume_root`, `logical_volume_nonroot`) with a single `[volume.<name>]` section where each entry has `volume_type = "standard_path" / "lv_root" / "lv_nonroot"`
- Add `VolumeType` enum in `backup_config.py`
- Unify `StandardPathJobConfig` and `LvJobConfig` into a single `VolumeConfig` dataclass
- `RESOURCE_DISPATCH` keys are now `VolumeType` enum values
- Update README config examples, quickstart, and CLI docs to match the new format

## Test plan

- [x] `pixi run test` — 78 tests pass
- [x] `sudo "$(command -v rlvm)" backup --config rudolph-backup.toml --dry-run` with new-format config

🤖 Generated with [Claude Code](https://claude.com/claude-code)