### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.0] — 2026-07-02
+
+### 🔌 API Changes
+- **New config format: `[volume.<name>]` with `volume_type`.**
+  The three top-level category sections (`standard_path`, `logical_volume_root`,
+  `logical_volume_nonroot`) are replaced by a single `[volume.<name>]` section
+  where each entry has a `volume_type` field (`standard_path`, `lv_root`, or
+  `lv_nonroot`). **Action:** update config files — see README for the new format.
+- **Named prune policies replace inline prune params.**
+  Define retention policies once in `[prune_policy.<name>]` sections and reference
+  them with `prune_policy = "<name>"` on each repository. Inline `prune_keep_*`
+  keys are no longer supported.
+
+### 🔧 Internal
+- `VolumeType` enum replaces string-based category dispatch.
+- `VolumeConfig` dataclass replaces `StandardPathJobConfig` / `LvJobConfig`.
+- `BackupConfig` simplified to `prune_policies` + `volumes` (was three separate dicts).
+- `BackupPlan` uses `BackupConfig`/`BackupConfigFactory` instead of raw config dicts;
+  deeply nested `create_backup_job` replaced by flat `_build_backup_job`.
+- `prune_runner` uses `BackupConfig` directly; `confirm_unique_repos` and
+  `resolve_prune_params` removed from `restic_repo.py`.
+
+### 📚 Documentation
+- README config examples, quickstart, and CLI docs updated for the new format.
+
+---
+
 ## [0.5.1] — 2026-07-01
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A minimal end-to-end example that backs up the `/home` logical volume to a local
 
 ```bash
 # 1. Install
-pip install git+https://github.com/duanegoodner/resticlvm.git@v0.5.0
+pip install git+https://github.com/duanegoodner/resticlvm.git@v0.6.0
 
 # 2. Create a password file and initialize the Restic repository (one-time)
 sudo mkdir -p /root/.config/resticlvm/repo-creds
@@ -121,7 +121,7 @@ For the full configuration reference (multiple/remote/cloud repositories, `copy_
 Install the latest release directly from GitHub:
 
 ```bash
-pip install git+https://github.com/duanegoodner/resticlvm.git@v0.5.0
+pip install git+https://github.com/duanegoodner/resticlvm.git@v0.6.0
 ```
 
 This installs the CLI tools:
@@ -493,7 +493,7 @@ Snapshots tagged protected will automatically be preserved during pruning, regar
 Replace the version tag with any release from the [releases page](https://github.com/duanegoodner/resticlvm/releases):
 
 ```bash
-pip install git+https://github.com/duanegoodner/resticlvm.git@v0.5.0
+pip install git+https://github.com/duanegoodner/resticlvm.git@v0.6.0
 ```
 
 #### Install from Main Branch
@@ -509,19 +509,19 @@ pip install git+https://github.com/duanegoodner/resticlvm.git@main
 Install with B2 CLI support for Backblaze B2 management:
 
 ```bash
-pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.5.0#egg=resticlvm[b2]"
+pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.6.0#egg=resticlvm[b2]"
 ```
 
 Install with development tools (pytest):
 
 ```bash
-pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.5.0#egg=resticlvm[dev]"
+pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.6.0#egg=resticlvm[dev]"
 ```
 
 Install with both B2 and development dependencies:
 
 ```bash
-pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.5.0#egg=resticlvm[dev,b2]"
+pip install "git+https://github.com/duanegoodner/resticlvm.git@v0.6.0#egg=resticlvm[dev,b2]"
 ```
 
 #### Clone and Install in Development Mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.5.1"
+version = "0.6.0"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0 in `pyproject.toml`
- Add 0.6.0 section to `CHANGELOG.md`
- Update README install version tags to v0.6.0

Breaking config format change: `[volume.<name>]` with `volume_type` enum, named prune policies. See CHANGELOG for migration details.

## Test plan

- [x] `pixi run test` — 78 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)