### PR TITLE
feat: default config path /etc/resticlvm/backup.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,23 @@ Run all backup jobs defined in a config (ResticLVM must run as root):
 sudo rlvm backup --config /path/to/your/backup-config.toml
 ```
 
+If your config is at the default location (`/etc/resticlvm/backup.toml`), you can
+omit `--config`:
+
+```bash
+sudo rlvm backup
+```
+
+You can also set the `RESTICLVM_CONFIG` environment variable to point to your config
+file, which takes precedence over the default location:
+
+```bash
+export RESTICLVM_CONFIG=/path/to/your/backup-config.toml
+sudo rlvm backup
+```
+
+Config precedence: `--config` flag > `$RESTICLVM_CONFIG` > `/etc/resticlvm/backup.toml`.
+
 Preview what would happen, without writing any backups, using `--dry-run`:
 
 ```bash
@@ -549,8 +566,9 @@ Changes to the source code are reflected immediately without reinstalling.
 ### CLI Help
 
 Both commands accept `--config`, `--category`, `--name`, `--dry-run`, `--version`, and
-`--help`. `--help` and `--version` work without root; running an actual backup or prune
-requires root.
+`--help`. `--config` is optional when a config exists at `/etc/resticlvm/backup.toml`
+(or `$RESTICLVM_CONFIG` is set). `--help` and `--version` work without root; running
+an actual backup or prune requires root.
 
 ```bash
 rlvm backup --help      # full option list

--- a/docs/EXAMPLE_SSH_SETUP.md
+++ b/docs/EXAMPLE_SSH_SETUP.md
@@ -197,7 +197,8 @@ if ! ssh-add -l &>/dev/null; then
     exit 1
 fi
 
-# Run backup
+# Run backup (/etc/resticlvm/backup.toml is the default config location,
+# so --config could be omitted here)
 /usr/local/bin/rlvm backup --config /etc/resticlvm/backup.toml &> "$LOGFILE"
 
 EXIT_CODE=$?

--- a/src/resticlvm/orchestration/cli.py
+++ b/src/resticlvm/orchestration/cli.py
@@ -1,17 +1,58 @@
 """Unified CLI entry point for ResticLVM."""
 
 import argparse
+import os
 import sys
+from pathlib import Path
 
 from resticlvm import __version__
 from resticlvm.orchestration.privileges import ensure_running_as_root
+
+DEFAULT_CONFIG_PATH = Path("/etc/resticlvm/backup.toml")
+CONFIG_ENV_VAR = "RESTICLVM_CONFIG"
+
+
+def resolve_config(explicit: str | None) -> Path:
+    """Return the config path from --config, env var, or default.
+
+    Precedence: explicit --config flag > $RESTICLVM_CONFIG > default path.
+    Exits with a clear message if the resolved path does not exist.
+    """
+    if explicit is not None:
+        path = Path(explicit)
+        if not path.is_file():
+            sys.exit(f"rlvm: config file not found: {path}")
+        return path
+
+    from_env = os.environ.get(CONFIG_ENV_VAR)
+    if from_env is not None:
+        path = Path(from_env)
+        if not path.is_file():
+            sys.exit(
+                f"rlvm: config file not found: {path}"
+                f" (from ${CONFIG_ENV_VAR})"
+            )
+        return path
+
+    if DEFAULT_CONFIG_PATH.is_file():
+        return DEFAULT_CONFIG_PATH
+
+    sys.exit(
+        f"rlvm: no config file found. Provide one with --config,"
+        f" set ${CONFIG_ENV_VAR},"
+        f" or place a config at {DEFAULT_CONFIG_PATH}"
+    )
 
 
 def _add_common_arguments(parser):
     parser.add_argument(
         "--config",
-        required=True,
-        help="Path to configuration TOML file.",
+        default=None,
+        help=(
+            "Path to configuration TOML file."
+            f" Default: {DEFAULT_CONFIG_PATH}"
+            f" (override with ${CONFIG_ENV_VAR})."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -58,6 +99,8 @@ def main():
     if args.command is None:
         parser.print_help()
         sys.exit(0)
+
+    args.config = str(resolve_config(args.config))
 
     ensure_running_as_root()
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,102 @@
+"""Tests for CLI config resolution and help output."""
+
+import pytest
+
+from resticlvm.orchestration.cli import (
+    CONFIG_ENV_VAR,
+    DEFAULT_CONFIG_PATH,
+    resolve_config,
+)
+
+
+# --- resolve_config precedence and error handling ---
+
+
+def test_explicit_config_returned(tmp_path):
+    f = tmp_path / "explicit.toml"
+    f.write_text("[prune_policy]\n")
+    assert resolve_config(str(f)) == f
+
+
+def test_explicit_config_missing_exits(tmp_path):
+    missing = tmp_path / "nope.toml"
+    with pytest.raises(SystemExit, match=str(missing)):
+        resolve_config(str(missing))
+
+
+def test_env_var_used_when_no_flag(tmp_path, monkeypatch):
+    f = tmp_path / "env.toml"
+    f.write_text("[prune_policy]\n")
+    monkeypatch.setenv(CONFIG_ENV_VAR, str(f))
+    assert resolve_config(None) == f
+
+
+def test_env_var_missing_file_exits(tmp_path, monkeypatch):
+    missing = tmp_path / "nope.toml"
+    monkeypatch.setenv(CONFIG_ENV_VAR, str(missing))
+    with pytest.raises(SystemExit, match=CONFIG_ENV_VAR):
+        resolve_config(None)
+
+
+def test_default_path_used_when_exists(tmp_path, monkeypatch):
+    f = tmp_path / "backup.toml"
+    f.write_text("[prune_policy]\n")
+    monkeypatch.setattr(
+        "resticlvm.orchestration.cli.DEFAULT_CONFIG_PATH", f
+    )
+    monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+    assert resolve_config(None) == f
+
+
+def test_nothing_found_exits(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "resticlvm.orchestration.cli.DEFAULT_CONFIG_PATH",
+        tmp_path / "nonexistent.toml",
+    )
+    monkeypatch.delenv(CONFIG_ENV_VAR, raising=False)
+    with pytest.raises(SystemExit, match="no config file found"):
+        resolve_config(None)
+
+
+def test_explicit_wins_over_env_and_default(tmp_path, monkeypatch):
+    explicit = tmp_path / "explicit.toml"
+    env_file = tmp_path / "env.toml"
+    default = tmp_path / "backup.toml"
+    for f in (explicit, env_file, default):
+        f.write_text("[prune_policy]\n")
+
+    monkeypatch.setenv(CONFIG_ENV_VAR, str(env_file))
+    monkeypatch.setattr(
+        "resticlvm.orchestration.cli.DEFAULT_CONFIG_PATH", default
+    )
+    assert resolve_config(str(explicit)) == explicit
+
+
+def test_env_wins_over_default(tmp_path, monkeypatch):
+    env_file = tmp_path / "env.toml"
+    default = tmp_path / "backup.toml"
+    for f in (env_file, default):
+        f.write_text("[prune_policy]\n")
+
+    monkeypatch.setenv(CONFIG_ENV_VAR, str(env_file))
+    monkeypatch.setattr(
+        "resticlvm.orchestration.cli.DEFAULT_CONFIG_PATH", default
+    )
+    assert resolve_config(None) == env_file
+
+
+# --- CLI help output ---
+
+
+def test_help_shows_default_path_and_env_var(capsys, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["rlvm", "backup", "--help"])
+
+    from resticlvm.orchestration.cli import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert str(DEFAULT_CONFIG_PATH) in out
+    assert CONFIG_ENV_VAR in out


### PR DESCRIPTION
## Summary

Closes #56.

- `--config` is now optional. When omitted, `rlvm` resolves the config via: explicit `--config` flag > `$RESTICLVM_CONFIG` env var > `/etc/resticlvm/backup.toml`
- Clear error message listing all sources checked when no config is found
- CLI `--help` shows the default path and env var
- 9 new tests covering resolution precedence, missing-file errors, and help output

## Test plan

- [x] `pixi run test` — all 87 tests pass (9 new in `test_cli.py`)
- [x] `pixi run lint-sh` — no regressions (all warnings pre-existing)
- [x] `rlvm backup --help` shows default path and `$RESTICLVM_CONFIG` in `--config` help text
- [x] `sudo rlvm backup --dry-run` (no `--config`) picks up `/etc/resticlvm/backup.toml` and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)