### PR TITLE
feat: warn when repo names within a volume don't match across locations

### DIFF
--- a/src/resticlvm/orchestration/backup_plan.py
+++ b/src/resticlvm/orchestration/backup_plan.py
@@ -12,6 +12,7 @@ from resticlvm.orchestration.backup_config import (
     VolumeType,
 )
 from resticlvm.orchestration.config_loader import load_config
+from resticlvm.orchestration.config_validator import warn_on_validation_issues
 from resticlvm.orchestration.data_classes import BackupJob, TokenConfigKeyPair
 from resticlvm.orchestration.dispatch import RESOURCE_DISPATCH
 from resticlvm.orchestration.restic_repo import (
@@ -57,6 +58,7 @@ class BackupPlan:
         self.dry_run = dry_run
         raw = load_config(config_path)
         self._config = BackupConfigFactory(raw).build()
+        warn_on_validation_issues(self._config)
 
     def _build_backup_job(
         self, name: str, vol_cfg: VolumeConfig

--- a/src/resticlvm/orchestration/config_validator.py
+++ b/src/resticlvm/orchestration/config_validator.py
@@ -1,11 +1,9 @@
 """Soft validation checks for a parsed BackupConfig."""
 
-import logging
+import sys
 from posixpath import basename as posix_basename
 
 from resticlvm.orchestration.backup_config import BackupConfig
-
-logger = logging.getLogger(__name__)
 
 
 def repo_name_from_path(repo_path: str) -> str:
@@ -57,6 +55,6 @@ def validate_config(config: BackupConfig) -> list[str]:
 
 
 def warn_on_validation_issues(config: BackupConfig) -> None:
-    """Run validation and log any warnings."""
+    """Run validation and print any warnings to stderr."""
     for warning in validate_config(config):
-        logger.warning(warning)
+        print(f"⚠️  WARNING: {warning}", file=sys.stderr)

--- a/src/resticlvm/orchestration/config_validator.py
+++ b/src/resticlvm/orchestration/config_validator.py
@@ -1,0 +1,62 @@
+"""Soft validation checks for a parsed BackupConfig."""
+
+import logging
+from posixpath import basename as posix_basename
+
+from resticlvm.orchestration.backup_config import BackupConfig
+
+logger = logging.getLogger(__name__)
+
+
+def repo_name_from_path(repo_path: str) -> str:
+    """Extract the final path component from a repo_path.
+
+    Handles local paths, sftp:user@host:/path, and s3:host/path.
+    """
+    path_part = repo_path
+    if ":" in repo_path:
+        path_part = repo_path.rsplit(":", maxsplit=1)[1]
+    return posix_basename(path_part.rstrip("/"))
+
+
+def validate_repo_names(config: BackupConfig) -> list[str]:
+    """Warn when repos within a volume have mismatched final path components.
+
+    Checks both primary repositories and their copy_to destinations.
+    Returns a list of warning strings (empty if everything is consistent).
+    """
+    warnings: list[str] = []
+
+    for vol_name, vol_cfg in config.volumes.items():
+        all_paths: list[str] = []
+        for repo in vol_cfg.repositories:
+            all_paths.append(repo.repo_path)
+            for dest in repo.copy_destinations:
+                all_paths.append(dest.repo_path)
+
+        if len(all_paths) <= 1:
+            continue
+
+        names = {p: repo_name_from_path(p) for p in all_paths}
+        unique_names = set(names.values())
+
+        if len(unique_names) > 1:
+            detail = ", ".join(
+                f"{path} -> '{name}'" for path, name in names.items()
+            )
+            warnings.append(
+                f"Volume '{vol_name}': repo names differ: {detail}"
+            )
+
+    return warnings
+
+
+def validate_config(config: BackupConfig) -> list[str]:
+    """Run all soft validation checks. Returns collected warnings."""
+    return validate_repo_names(config)
+
+
+def warn_on_validation_issues(config: BackupConfig) -> None:
+    """Run validation and log any warnings."""
+    for warning in validate_config(config):
+        logger.warning(warning)

--- a/src/resticlvm/orchestration/config_validator.py
+++ b/src/resticlvm/orchestration/config_validator.py
@@ -57,4 +57,4 @@ def validate_config(config: BackupConfig) -> list[str]:
 def warn_on_validation_issues(config: BackupConfig) -> None:
     """Run validation and print any warnings to stderr."""
     for warning in validate_config(config):
-        print(f"⚠️  WARNING: {warning}", file=sys.stderr)
+        print(f"⚠️  WARNING: {warning}\n", file=sys.stderr)

--- a/test/test_config_validator.py
+++ b/test/test_config_validator.py
@@ -287,3 +287,4 @@ def test_warn_on_validation_issues_prints_to_stderr(capsys):
     assert captured.out == ""
     assert "WARNING" in captured.err
     assert "efi" in captured.err
+    assert captured.err.endswith("\n\n")

--- a/test/test_config_validator.py
+++ b/test/test_config_validator.py
@@ -1,7 +1,5 @@
 """Tests for config_validator module."""
 
-import logging
-
 import pytest
 
 from resticlvm.orchestration.backup_config import BackupConfigFactory
@@ -260,7 +258,7 @@ def test_multiple_volumes_warns_only_mismatched():
 # --- warn_on_validation_issues logs warnings ---
 
 
-def test_warn_on_validation_issues_logs(caplog):
+def test_warn_on_validation_issues_prints_to_stderr(capsys):
     raw = {
         "prune_policy": {"standard": STANDARD_POLICY},
         "volume": {
@@ -283,9 +281,9 @@ def test_warn_on_validation_issues_logs(caplog):
         },
     }
     config = _build_config(raw)
-    with caplog.at_level(logging.WARNING):
-        warn_on_validation_issues(config)
+    warn_on_validation_issues(config)
 
-    assert len(caplog.records) == 1
-    assert "efi" in caplog.records[0].message
-    assert caplog.records[0].levelno == logging.WARNING
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "WARNING" in captured.err
+    assert "efi" in captured.err

--- a/test/test_config_validator.py
+++ b/test/test_config_validator.py
@@ -1,0 +1,291 @@
+"""Tests for config_validator module."""
+
+import logging
+
+import pytest
+
+from resticlvm.orchestration.backup_config import BackupConfigFactory
+from resticlvm.orchestration.config_validator import (
+    repo_name_from_path,
+    validate_config,
+    warn_on_validation_issues,
+)
+
+
+STANDARD_POLICY = {
+    "keep_last": 10,
+    "keep_daily": 7,
+    "keep_weekly": 4,
+    "keep_monthly": 6,
+    "keep_yearly": 1,
+}
+
+
+# --- repo_name_from_path ---
+
+
+@pytest.mark.parametrize(
+    "repo_path, expected",
+    [
+        ("/srv/backup/efi-01", "efi-01"),
+        ("/backup/resticlvm/efi-01/", "efi-01"),
+        ("sftp:user@host:/data/resticlvm/efi-01", "efi-01"),
+        (
+            "s3:s3.us-west-004.backblazeb2.com/bucket/resticlvm/efi-01",
+            "efi-01",
+        ),
+        ("sftp:user@host:/efi-01/", "efi-01"),
+        ("s3:bucket/efi-01/", "efi-01"),
+        ("/efi-01", "efi-01"),
+    ],
+)
+def test_repo_name_from_path(repo_path, expected):
+    assert repo_name_from_path(repo_path) == expected
+
+
+# --- validate_config: matching names ---
+
+
+def _build_config(raw):
+    return BackupConfigFactory(raw).build()
+
+
+def test_matching_repo_names_no_warnings():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "efi": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot/efi",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/efi-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/efi-01",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "s3:bucket/efi-01",
+                        "password_file": "/tmp/pw3.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            }
+        },
+    }
+    assert validate_config(_build_config(raw)) == []
+
+
+def test_single_repo_no_warnings():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "boot": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/boot-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            }
+        },
+    }
+    assert validate_config(_build_config(raw)) == []
+
+
+def test_no_repos_no_warnings():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "boot": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot",
+                "repositories": [],
+            }
+        },
+    }
+    assert validate_config(_build_config(raw)) == []
+
+
+def test_empty_config_no_warnings():
+    assert validate_config(_build_config({})) == []
+
+
+# --- validate_config: mismatched names ---
+
+
+def test_mismatched_repo_names_warns():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "efi": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot/efi",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/efi-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/egi-01",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            }
+        },
+    }
+    warnings = validate_config(_build_config(raw))
+    assert len(warnings) == 1
+    assert "efi" in warnings[0]
+    assert "efi-01" in warnings[0]
+    assert "egi-01" in warnings[0]
+
+
+def test_mismatched_copy_dest_warns():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "boot": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/boot-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                        "copy_to": [
+                            {
+                                "repo": "sftp:host:/backup/boot-02",
+                                "password_file": "/tmp/pw2.txt",
+                                "prune_policy": "standard",
+                            },
+                        ],
+                    },
+                ],
+            }
+        },
+    }
+    warnings = validate_config(_build_config(raw))
+    assert len(warnings) == 1
+    assert "boot-01" in warnings[0]
+    assert "boot-02" in warnings[0]
+
+
+def test_matching_with_copy_dest_no_warnings():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "boot": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/boot-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                        "copy_to": [
+                            {
+                                "repo": "sftp:host:/backup/boot-01",
+                                "password_file": "/tmp/pw2.txt",
+                                "prune_policy": "standard",
+                            },
+                        ],
+                    },
+                    {
+                        "repo_path": "s3:bucket/boot-01",
+                        "password_file": "/tmp/pw3.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            }
+        },
+    }
+    assert validate_config(_build_config(raw)) == []
+
+
+def test_multiple_volumes_warns_only_mismatched():
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "efi": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot/efi",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/efi-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/efi-01",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            },
+            "root": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/root-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/root-99",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            },
+        },
+    }
+    warnings = validate_config(_build_config(raw))
+    assert len(warnings) == 1
+    assert "root" in warnings[0]
+    assert "root-01" in warnings[0]
+    assert "root-99" in warnings[0]
+
+
+# --- warn_on_validation_issues logs warnings ---
+
+
+def test_warn_on_validation_issues_logs(caplog):
+    raw = {
+        "prune_policy": {"standard": STANDARD_POLICY},
+        "volume": {
+            "efi": {
+                "volume_type": "standard_path",
+                "backup_source_path": "/boot/efi",
+                "repositories": [
+                    {
+                        "repo_path": "/backup/efi-01",
+                        "password_file": "/tmp/pw.txt",
+                        "prune_policy": "standard",
+                    },
+                    {
+                        "repo_path": "sftp:host:/backup/egi-01",
+                        "password_file": "/tmp/pw2.txt",
+                        "prune_policy": "standard",
+                    },
+                ],
+            }
+        },
+    }
+    config = _build_config(raw)
+    with caplog.at_level(logging.WARNING):
+        warn_on_validation_issues(config)
+
+    assert len(caplog.records) == 1
+    assert "efi" in caplog.records[0].message
+    assert caplog.records[0].levelno == logging.WARNING


### PR DESCRIPTION
## Summary

- Adds a new `config_validator.py` module with soft validation that extracts the final path component from each `repo_path` (local, `sftp:`, `s3:`) within a volume — including `copy_to` destinations — and logs a warning when they differ.
- Wired into `BackupPlan.__init__` so both `backup` and `prune` subcommands see the warnings.
- 16 new tests covering path extraction across URL schemes, match/mismatch scenarios, copy destinations, and log output.

Closes #55

## Test plan

- [x] All 103 tests pass (`pixi run test`)
- [x] Shellcheck clean (no new warnings from `pixi run lint-sh`)
- [x] Manual verification: create a config with mismatched repo names and confirm the warning appears in CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)