### PR TITLE
release: bump version to 0.7.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.7.0] — 2026-07-03
+
+### ✨ New Features
+- **Default config path.** `--config` is now optional — `rlvm` falls back to
+  `$RESTICLVM_CONFIG` then `/etc/resticlvm/backup.toml`. (#56)
+- **Repo name mismatch warning.** When repos within a volume have different final
+  path components (e.g. `efi-01` vs `egi-01`), a warning is printed to stderr
+  before the run starts. Checks both primary repositories and `copy_to`
+  destinations. (#55)
+
+### 🔧 Internal
+- New `config_validator` module for soft validation checks on parsed configs.
+
+---
+
 ## [0.6.0] — 2026-07-02
 
 ### 🔌 API Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "resticlvm"
-version = "0.6.0"
+version = "0.7.0"
 description = "Restic + LVM backup orchestration tool"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version `0.6.0` → `0.7.0` in `pyproject.toml`
- Add `[0.7.0]` section to CHANGELOG covering:
  - Default config path (`--config` optional, falls back to `$RESTICLVM_CONFIG` / `/etc/resticlvm/backup.toml`) (#56)
  - Repo name mismatch warning (#55)
  - New `config_validator` module

## Test plan

- [x] `pixi run test` — 103 passed
- [x] Phase 0 pre-flight: real backup on production host (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)