### PR TITLE
chore: re-clone vm-builder from upstream (92656f9)

### DIFF
--- a/dev/vm-builder/.github/workflows/mirror-to-gitlab.yml
+++ b/dev/vm-builder/.github/workflows/mirror-to-gitlab.yml
@@ -1,0 +1,32 @@
+name: Mirror to GitLab
+on:
+  push:
+    branches: [main]
+concurrency:
+  group: gitlab-mirror
+  cancel-in-progress: true
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for GitLab token
+        run: |
+          if [ -z "${{ secrets.GITLAB_MIRROR_TOKEN }}" ]; then
+            echo "::error::GITLAB_MIRROR_TOKEN secret is not set"
+            exit 1
+          fi
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push to GitLab
+        run: |
+          if [ "${{ github.repository_owner }}" = "duanegoodner" ]; then
+            GITLAB_NS="duane.goodner"
+          else
+            GITLAB_NS="${{ github.repository_owner }}"
+          fi
+          REPO_NAME="${{ github.event.repository.name }}"
+          git -c credential.helper='!f() { echo "username=oauth2"; echo "password=${GITLAB_TOKEN}"; }; f' \
+            push --force "https://gitlab.com/${GITLAB_NS}/${REPO_NAME}.git" main
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}

--- a/dev/vm-builder/README.md
+++ b/dev/vm-builder/README.md
@@ -1,6 +1,6 @@
-# VM Builder - Debian VMs with LVM Root
+**Note:** This directory was cloned from [https://github.com/duanegoodner/vm-builder](https://github.com/duanegoodner/vm-builder) at commit [92656f9](https://github.com/duanegoodner/vm-builder/commit/92656f9). The `.git/` directory and a top-level `archive/` directory were removed from the clone before adding to the ResticLVM repository. We aim to avoid editing the content of `dev/vm-builder/` directly (preferring to make changes in the original repository and re-clone), but cannot guarantee that no local edits have been made.
 
-> **Note:** This directory was cloned from [https://github.com/duanegoodner/vm-builder](https://github.com/duanegoodner/vm-builder) at commit [6bdd04dc70f9c61dfec98fac3e4f26d484c208d8](https://github.com/duanegoodner/vm-builder/commit/6bdd04dc70f9c61dfec98fac3e4f26d484c208d8). The `.git/` directory and a top-level `archive/` directory were removed from the clone before adding to the ResticLVM repository. We aim to avoid editing the content of `dev/vm-builder/` directly (preferring to make changes in the original repository and re-clone), but cannot guarantee that no local edits have been made.
+# VM Builder - Debian VMs with LVM Root
 
 Build and deploy Debian VMs with LVM root filesystem for snapshot testing. Works for both local KVM and AWS.
 
@@ -27,19 +27,14 @@ ssh -i ~/.ssh/your-key.pem debian@<PUBLIC_IP>
 This project creates Debian VMs with this filesystem layout:
 
 ```
-NAME                    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
-vda                     254:0    0    2G  0 disk 
-└─vda1                  254:1    0    2G  0 part /boot/efi
-vdb                     254:16   0   10G  0 disk 
-├─vg0-lv_root           253:0    0    8G  0 lvm  /
+NAME            MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
+vda             254:0    0    2G  0 disk 
+└─vda1          254:1    0    2G  0 part /boot/efi
+vdb             254:16   0   10G  0 disk 
+├─vg0-lv_root   253:0    0    8G  0 lvm  /
 └─(2G free in vg0)
-vdc                     254:32   0   10G  0 disk 
-└─vg1-lv_backup         253:1    0   10G  0 lvm  /srv/backup
-vdd                     254:48   0    5G  0 disk 
-├─vg2-lv_data           253:2    0    2G  0 lvm  /srv/data_lv
-└─(3G free in vg2)
-vde                     254:64   0    5G  0 disk 
-└─vde1                  254:65   0    5G  0 part /srv/data_standard_partition
+vdc             254:32   0   20G  0 disk 
+└─vg1-lv_backup 253:1    0   20G  0 lvm  /srv/backup
 ```
 
 Perfect for:
@@ -74,8 +69,9 @@ Optional tools and disk sizes are configured in `common/config/`:
 
 **Optional Tools** ([common/config/optional-tools.sh](common/config/optional-tools.sh)):
 ```bash
-export INSTALL_MINICONDA=false  # Set to true to include
-export INSTALL_RESTIC=false     # Set to true to include
+export INSTALL_MINICONDA=false  # Python env via miniconda
+export INSTALL_PIXI=true        # Python env via pixi
+export INSTALL_RESTIC=true      # Restic backup tool
 ```
 
 **Disk Sizes** ([common/config/vm-sizes.sh](common/config/vm-sizes.sh)):
@@ -101,8 +97,8 @@ cd packer-local
 # Build with default settings
 ./scripts/build.sh
 
-# OR build with optional tools
-INSTALL_MINICONDA=true INSTALL_RESTIC=true ./scripts/build.sh
+# OR override defaults (e.g. miniconda instead of pixi)
+INSTALL_MINICONDA=true INSTALL_PIXI=false ./scripts/build.sh
 ```
 
 Output: `output/debian13-local/debian13-local` (plus 2 additional disk images)  
@@ -144,9 +140,7 @@ ssh -i ~/.ssh/vm-dev debian@<IP>
 Final disk layout:
 - `/boot/efi` - 2GB EFI partition
 - `/` - 8GB LVM (vg0-lv_root) with 2GB free in vg0
-- `/srv/backup` - 10GB LVM (vg1-lv_backup)
-- `/srv/data_lv` - 2GB LVM (vg2-lv_data) with 3GB free in vg2
-- `/srv/data_standard_partition` - 5GB standard partition
+- `/srv/backup` - 20GB LVM (vg1-lv_backup)
 
 ### AWS Build & Deploy
 
@@ -158,8 +152,8 @@ cd packer-aws
 # Build with default settings
 ./scripts/build.sh
 
-# OR build with optional tools
-INSTALL_MINICONDA=true INSTALL_RESTIC=true ./scripts/build.sh
+# OR override defaults (e.g. miniconda instead of pixi)
+INSTALL_MINICONDA=true INSTALL_PIXI=false ./scripts/build.sh
 ```
 
 Output: AMI in your AWS account (check output for AMI ID)  

--- a/dev/vm-builder/common/ansible/roles/base/tasks/main.yml
+++ b/dev/vm-builder/common/ansible/roles/base/tasks/main.yml
@@ -19,7 +19,6 @@
       - parted
     state: present
     update_cache: yes
-    cache_valid_time: 86400
   tags:
     - base
     - packages

--- a/dev/vm-builder/common/ansible/roles/optional-tools/tasks/main.yml
+++ b/dev/vm-builder/common/ansible/roles/optional-tools/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Optional tools installation
-# Controlled by environment variables: INSTALL_MINICONDA, INSTALL_RESTIC
+# Controlled by environment variables: INSTALL_MINICONDA, INSTALL_PIXI, INSTALL_RESTIC
 
 - name: Install restic backup tool
   when: lookup('env', 'INSTALL_RESTIC') == 'true'
@@ -68,3 +68,32 @@
       when: not miniconda_installed.stat.exists
       debug:
         msg: "Miniconda installed at /home/debian/miniconda3 for user debian"
+
+- name: Install pixi
+  when: lookup('env', 'INSTALL_PIXI') == 'true'
+  block:
+    - name: Check if pixi is already installed
+      stat:
+        path: /home/debian/.pixi/bin/pixi
+      register: pixi_installed
+
+    - name: Install pixi via official installer
+      when: not pixi_installed.stat.exists
+      become: true
+      become_user: debian
+      shell: curl -fsSL https://pixi.sh/install.sh | bash
+      args:
+        creates: /home/debian/.pixi/bin/pixi
+
+    - name: Verify pixi installation
+      when: not pixi_installed.stat.exists
+      become: true
+      become_user: debian
+      shell: /home/debian/.pixi/bin/pixi --version
+      register: pixi_version
+      changed_when: false
+
+    - name: Display pixi version
+      when: not pixi_installed.stat.exists
+      debug:
+        msg: "Installed pixi {{ pixi_version.stdout }}"

--- a/dev/vm-builder/common/config/optional-tools.sh
+++ b/dev/vm-builder/common/config/optional-tools.sh
@@ -5,7 +5,8 @@
 # Used by both local and AWS builds
 
 # Set to 'true' to install, 'false' to skip
-export INSTALL_MINICONDA=${INSTALL_MINICONDA:-true}
+export INSTALL_MINICONDA=${INSTALL_MINICONDA:-false}
+export INSTALL_PIXI=${INSTALL_PIXI:-true}
 export INSTALL_RESTIC=${INSTALL_RESTIC:-true}
 
 # Tool versions

--- a/dev/vm-builder/common/config/vm-sizes.sh
+++ b/dev/vm-builder/common/config/vm-sizes.sh
@@ -36,17 +36,6 @@ export VM_LVM_LV_ROOT_SIZE="10G"
 #   - Should match deployment BACKUP_DISK_SIZE
 export VM_BACKUP_DISK_SIZE="10G"
 
-# Data LVM disk: Test disk with LVM for /srv/data_lv
-#   - 5G volume group with 2G logical volume
-#   - Used for testing LVM snapshots with small dataset
-export VM_DATA_LV_DISK_SIZE="5G"
-export VM_DATA_LV_LV_SIZE="2G"
-
-# Data standard partition: Test disk with regular partition for /srv/data_standard_partition
-#   - 5G standard ext4 partition (no LVM)
-#   - Used for comparison testing vs LVM
-export VM_DATA_PARTITION_DISK_SIZE="1G"
-
 # Deployment Disk Sizes
 # ---------------------
 # EFI disk: Dedicated /boot/efi partition
@@ -111,10 +100,7 @@ if [ -n "$VM_SIZES_DEBUG" ]; then
   echo "VM Size Configuration Loaded:"
   echo "  Source Image Disk: $VM_SOURCE_IMAGE_DISK_SIZE"
   echo "  LVM Disk:          $VM_LVM_DISK_SIZE"
-  echo "  LVM LV Root:       $VM_LVM_LV_ROOT_SIZE"
   echo "  Backup Disk:       $VM_BACKUP_DISK_SIZE"
-  echo "  Data LV Disk:      $VM_DATA_LV_DISK_SIZE (LV: $VM_DATA_LV_LV_SIZE)"
-  echo "  Data Part Disk:    $VM_DATA_PARTITION_DISK_SIZE"
   echo "  EFI Disk:          $VM_EFI_DISK_SIZE"
   echo "  Build Memory:      ${VM_BUILD_MEMORY}MB"
   echo "  Build CPUs:        $VM_BUILD_CPUS"

--- a/dev/vm-builder/deploy-local/README.md
+++ b/dev/vm-builder/deploy-local/README.md
@@ -39,13 +39,11 @@ sudo ./deploy.sh ../packer-local/output/debian13-local/debian13-local \
 
 ## Deployment Process
 
-1. Creates VM with 6 disks:
+1. Creates VM with 4 disks:
    - `/dev/vda` (2GB) - EFI boot partition
    - `/dev/vdb` (1MB) - BIOS boot (compatibility)
    - `/dev/vdc` (10GB) - LVM root volume
-   - `/dev/vdd` (10GB) - Backup volume
-   - `/dev/vde` (5GB) - Data LV volume (LVM with 2GB LV)
-   - `/dev/vdf` (5GB) - Data standard partition
+   - `/dev/vdd` (20GB) - Backup volume
 2. Attaches cloud-init ISO with SSH keys and configuration
 3. VM boots and cloud-init configures hostname/SSH/network
 4. `lvm-migrate.service` runs automatically (migrates to LVM)

--- a/dev/vm-builder/deploy-local/deploy.sh
+++ b/dev/vm-builder/deploy-local/deploy.sh
@@ -18,8 +18,6 @@ VCPUS=${VM_DEPLOY_VCPUS}
 EFI_DISK_SIZE=${VM_EFI_DISK_SIZE%G}     # Remove G suffix for script processing
 LVM_DISK_SIZE=${VM_LVM_DISK_SIZE%G}     # Remove G suffix for script processing
 BACKUP_DISK_SIZE=${VM_BACKUP_DISK_SIZE%G} # Remove G suffix for script processing
-DATA_LV_DISK_SIZE=${VM_DATA_LV_DISK_SIZE%G} # Remove G suffix
-DATA_PARTITION_DISK_SIZE=${VM_DATA_PARTITION_DISK_SIZE%G} # Remove G suffix
 
 NETWORK="default"
 DISK_DIR="/var/lib/libvirt/images"
@@ -259,20 +257,6 @@ sudo qemu-img create -f qcow2 "$BACKUP_DISK" "${BACKUP_DISK_SIZE}G"
 sudo chown libvirt-qemu:kvm "$BACKUP_DISK"
 echo -e "${GREEN}✓ Backup disk ready (vdd - permanent)${NC}"
 
-# Create data LV disk (will hold /srv/data_lv with LVM)
-echo -e "${YELLOW}Creating data LV disk (${DATA_LV_DISK_SIZE}GB)...${NC}"
-DATA_LV_DISK="${DISK_DIR}/${VM_NAME}-data-lv.qcow2"
-sudo qemu-img create -f qcow2 "$DATA_LV_DISK" "${DATA_LV_DISK_SIZE}G"
-sudo chown libvirt-qemu:kvm "$DATA_LV_DISK"
-echo -e "${GREEN}✓ Data LV disk ready (vde - permanent)${NC}"
-
-# Create data partition disk (will hold /srv/data_standard_partition)
-echo -e "${YELLOW}Creating data partition disk (${DATA_PARTITION_DISK_SIZE}GB)...${NC}"
-DATA_PARTITION_DISK="${DISK_DIR}/${VM_NAME}-data-partition.qcow2"
-sudo qemu-img create -f qcow2 "$DATA_PARTITION_DISK" "${DATA_PARTITION_DISK_SIZE}G"
-sudo chown libvirt-qemu:kvm "$DATA_PARTITION_DISK"
-echo -e "${GREEN}✓ Data partition disk ready (vdf - permanent)${NC}"
-
 # Create VM
 echo -e "${YELLOW}Creating VM...${NC}"
 sudo virt-install \
@@ -283,8 +267,6 @@ sudo virt-install \
   --disk path="$EFI_DISK",format=qcow2,bus=virtio,boot_order=1 \
   --disk path="$LVM_DISK",format=qcow2,bus=virtio,boot_order=2 \
   --disk path="$BACKUP_DISK",format=qcow2,bus=virtio,boot_order=4 \
-  --disk path="$DATA_LV_DISK",format=qcow2,bus=virtio,boot_order=5 \
-  --disk path="$DATA_PARTITION_DISK",format=qcow2,bus=virtio,boot_order=6 \
   --disk path="$CLOUD_INIT_ISO",device=cdrom,bus=scsi \
   --controller type=scsi,model=virtio-scsi \
   --network network="$NETWORK",model=virtio \

--- a/dev/vm-builder/packer-aws/scripts/build.sh
+++ b/dev/vm-builder/packer-aws/scripts/build.sh
@@ -30,6 +30,7 @@ echo "  Backup Volume:     ${AWS_BACKUP_VOLUME_SIZE}GB ($AWS_VOLUME_TYPE) - for 
 echo ""
 echo "Optional Tools:"
 echo "  Miniconda:         $INSTALL_MINICONDA"
+echo "  Pixi:              $INSTALL_PIXI"
 echo "  Restic:            $INSTALL_RESTIC"
 echo ""
 

--- a/dev/vm-builder/packer-local/ansible/roles/lvm-migration/files/lvm-migrate.service
+++ b/dev/vm-builder/packer-local/ansible/roles/lvm-migration/files/lvm-migrate.service
@@ -7,7 +7,6 @@ ConditionPathExists=!/var/lib/lvm-migrate-done
 [Service]
 Type=oneshot
 Environment="LVM_LV_ROOT_SIZE=8G"
-Environment="DATA_LV_SIZE=2G"
 ExecStart=/bin/bash /root/lvm-migrate.sh
 ExecStartPost=/bin/touch /var/lib/lvm-migrate-done
 ExecStartPost=/bin/systemctl disable lvm-migrate.service

--- a/dev/vm-builder/packer-local/ansible/roles/lvm-migration/files/lvm-migrate.sh
+++ b/dev/vm-builder/packer-local/ansible/roles/lvm-migration/files/lvm-migrate.sh
@@ -5,8 +5,6 @@
 #   EFI_DISK: EFI partition mounted at /boot/efi
 #   LVM_DISK: LVM (vg0-lv_root) mounted at / (contains /boot directory)
 #   BACKUP_DISK: LVM (vg1-lv_backup) mounted at /srv/backup
-#   DATA_LV_DISK: LVM (vg2-lv_data) mounted at /srv/data_lv
-#   DATA_PARTITION_DISK: Standard partition mounted at /srv/data_standard_partition
 #   BOOT_DISK: Original cloud image (to be deleted after successful migration)
 #
 # Environment variables (optional):
@@ -14,9 +12,6 @@
 #   LVM_DISK: Disk for LVM root (default: /dev/vdc)
 #   LVM_LV_ROOT_SIZE: Size for lv_root logical volume (default: 100%FREE)
 #   BACKUP_DISK: Disk for backup LVM (default: /dev/vdd)
-#   DATA_LV_DISK: Disk for data LVM (default: /dev/vde)
-#   DATA_LV_SIZE: Size for lv_data logical volume (default: 2G)
-#   DATA_PARTITION_DISK: Disk for standard partition (default: /dev/vdf)
 #   BOOT_DISK: Original boot disk (default: /dev/vda)
 #   CURRENT_EFI: Current EFI partition (default: /dev/vda15)
 
@@ -40,22 +35,15 @@ EFI_DISK="${EFI_DISK:-/dev/vdb}"        # Will hold EFI partition
 LVM_DISK="${LVM_DISK:-/dev/vdc}"        # Will hold LVM root
 LVM_LV_ROOT_SIZE="${LVM_LV_ROOT_SIZE:-100%FREE}"  # Size for lv_root (can be specific size like 8G)
 BACKUP_DISK="${BACKUP_DISK:-/dev/vdd}"  # Will hold backup LVM
-DATA_LV_DISK="${DATA_LV_DISK:-/dev/vde}"  # Will hold data LVM
-DATA_LV_SIZE="${DATA_LV_SIZE}"          # Size for lv_data logical volume (set by service)
-DATA_PARTITION_DISK="${DATA_PARTITION_DISK:-/dev/vdf}"  # Will hold standard partition
 BOOT_DISK="${BOOT_DISK:-/dev/vda}"      # Original boot disk
 CURRENT_EFI="${CURRENT_EFI:-/dev/vda15}" # EFI partition in cloud image
 EFI_PART="${EFI_DISK}1"
-DATA_PARTITION="${DATA_PARTITION_DISK}1"
 
 echo "Configuration:"
 echo "  EFI Disk:         $EFI_DISK"
 echo "  LVM Disk:         $LVM_DISK"
 echo "  LV Root Size:     $LVM_LV_ROOT_SIZE"
 echo "  Backup Disk:      $BACKUP_DISK"
-echo "  Data LV Disk:     $DATA_LV_DISK"
-echo "  Data LV Size:     $DATA_LV_SIZE"
-echo "  Data Part Disk:   $DATA_PARTITION_DISK"
 echo "  Boot Disk:        $BOOT_DISK"
 echo "  Current EFI:      $CURRENT_EFI"
 
@@ -112,48 +100,6 @@ if [ -n "$BACKUP_DISK" ]; then
         echo "Backup LVM setup complete!"
     else
         echo "Backup LVM already exists."
-    fi
-fi
-
-# Create data LVM if data LV disk exists
-if [ -n "$DATA_LV_DISK" ]; then
-    echo "Checking data LVM configuration..."
-    if ! lvdisplay /dev/vg2/lv_data &>/dev/null; then
-        echo "Creating data LVM structure on $DATA_LV_DISK..."
-        
-        # Create data LVM structure (vg2 with lv_data)
-        pvcreate "$DATA_LV_DISK"
-        vgcreate vg2 "$DATA_LV_DISK"
-        lvcreate -L "$DATA_LV_SIZE" -n lv_data vg2
-        mkfs.ext4 /dev/vg2/lv_data
-        
-        # Show VG status to display free space
-        vgs vg2
-        echo "Data LVM setup complete!"
-    else
-        echo "Data LVM already exists."
-    fi
-fi
-
-# Create standard partition if data partition disk exists
-if [ -n "$DATA_PARTITION_DISK" ]; then
-    echo "Checking data partition configuration..."
-    if ! blkid "$DATA_PARTITION" &>/dev/null; then
-        echo "Creating standard partition on $DATA_PARTITION_DISK..."
-        
-        # Create partition table and partition
-        parted -s "$DATA_PARTITION_DISK" mklabel gpt
-        parted -s "$DATA_PARTITION_DISK" mkpart primary ext4 0% 100%
-        
-        # Force kernel to re-read partition table
-        partprobe "$DATA_PARTITION_DISK"
-        sleep 1  # Give kernel a moment to register the new partition
-        
-        # Format partition
-        mkfs.ext4 "$DATA_PARTITION"
-        echo "Standard partition setup complete!"
-    else
-        echo "Data partition already exists."
     fi
 fi
 
@@ -216,24 +162,6 @@ if [ -n "$BACKUP_DISK" ]; then
     mkdir -p /mnt/newroot/srv/backup
 fi
 
-# Add data LV to fstab if it exists
-if [ -n "$DATA_LV_DISK" ]; then
-    DATA_LV_UUID=$(blkid -s UUID -o value /dev/vg2/lv_data)
-    echo "UUID=$DATA_LV_UUID  /srv/data_lv ext4    defaults        0       2" >> /mnt/newroot/etc/fstab
-    
-    # Create data_lv mount point in new root
-    mkdir -p /mnt/newroot/srv/data_lv
-fi
-
-# Add data partition to fstab if it exists
-if [ -n "$DATA_PARTITION_DISK" ]; then
-    DATA_PART_UUID=$(blkid -s UUID -o value "$DATA_PARTITION")
-    echo "UUID=$DATA_PART_UUID  /srv/data_standard_partition ext4    defaults        0       2" >> /mnt/newroot/etc/fstab
-    
-    # Create data_standard_partition mount point in new root
-    mkdir -p /mnt/newroot/srv/data_standard_partition
-fi
-
 # Chroot and update GRUB
 echo "Updating GRUB configuration..."
 mount --bind /dev /mnt/newroot/dev
@@ -267,12 +195,6 @@ echo "  vdb1: EFI partition (/boot/efi)"
 echo "  vdc:  LVM root (/) with /boot directory"
 if [ -n "$BACKUP_DISK" ]; then
     echo "  vdd:  LVM backup (/srv/backup)"
-fi
-if [ -n "$DATA_LV_DISK" ]; then
-    echo "  vde:  LVM data (/srv/data_lv) - vg2/lv_data $DATA_LV_SIZE in $(echo $VM_DATA_LV_DISK_SIZE | sed 's/G//') GB VG"
-fi
-if [ -n "$DATA_PARTITION_DISK" ]; then
-    echo "  vdf1: Standard partition (/srv/data_standard_partition)"
 fi
 echo "  vda:  Original cloud image (can be deleted after successful boot)"
 echo ""

--- a/dev/vm-builder/packer-local/debian-cloud.pkr.hcl
+++ b/dev/vm-builder/packer-local/debian-cloud.pkr.hcl
@@ -28,7 +28,7 @@ source "qemu" "debian_local" {
   # It must be >= the cloud image size (typically 2GB).
   # In deployed VMs, this becomes a temporary disk that gets cleaned up after LVM migration.
   disk_image       = true
-  iso_url          = var.cloud_image_url
+  iso_urls         = [var.cloud_image_url, var.cloud_image_fallback_url]
   iso_checksum     = var.cloud_image_checksum
   disk_size        = var.source_image_disk_size
   disk_interface   = "virtio"

--- a/dev/vm-builder/packer-local/scripts/build.sh
+++ b/dev/vm-builder/packer-local/scripts/build.sh
@@ -29,6 +29,7 @@ echo "  Build CPUs:        $VM_BUILD_CPUS"
 echo ""
 echo "Optional Tools:"
 echo "  Miniconda:         $INSTALL_MINICONDA"
+echo "  Pixi:              $INSTALL_PIXI"
 echo "  Restic:            $INSTALL_RESTIC"
 echo ""
 

--- a/dev/vm-builder/packer-local/variables.pkr.hcl
+++ b/dev/vm-builder/packer-local/variables.pkr.hcl
@@ -62,12 +62,18 @@ variable "debian_version" {
 variable "cloud_image_url" {
   type    = string
   default = "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
-  description = "URL to Debian genericcloud image"
+  description = "Primary URL to Debian genericcloud image"
+}
+
+variable "cloud_image_fallback_url" {
+  type    = string
+  default = "https://gemmei.ftp.acc.umu.se/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
+  description = "Fallback mirror URL for Debian genericcloud image"
 }
 
 variable "cloud_image_checksum" {
   type    = string
-  default = "file:https://cloud.debian.org/images/cloud/trixie/latest/SHA512SUMS"
+  default = "file:https://gemmei.ftp.acc.umu.se/images/cloud/trixie/latest/SHA512SUMS"
   description = "Checksum for cloud image verification"
 }
 


### PR DESCRIPTION
## Summary
- Re-clone `dev/vm-builder/` from `duanegoodner/vm-builder` at merge commit 92656f9 (PR #4 merged)
- Updates provenance note in README with new commit hash
- Brings in pixi support, fallback mirror URL, apt cache fix, and GitLab mirror workflow from upstream

## Context
Upstream vm-builder PR #4 added pixi as an optional tool (replacing miniconda as the default Python env manager) for resticlvm issue #24 VM-based development work.

## Test plan
- [x] Upstream PR #4 test plan passed (default build with pixi, override build with miniconda)
- [x] Verify `dev/vm-builder/` content matches upstream at 92656f9

🤖 Generated with [Claude Code](https://claude.com/claude-code)