### PR TITLE
docs: add issue #24 plan, VM status, and update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,12 +35,16 @@ layer (`src/resticlvm/orchestration`) drives focused Bash scripts
 ## Status & next work
 
 - Pre-1.0. Run **attended**: a mid-run failure can leak the LVM snapshot and its
-  mounts (cleanup-on-failure is not yet automatic).
-- **Next immediate task: issue #55** — warn when repo names within a volume don't
-  match across locations. New feature (config validation), minor version bump.
+  mounts (cleanup-on-failure is not yet automatic — this is issue #24, below).
+- **Next major task: Critical #2 / issue #24** (the LVM cleanup trap). The most common
+  leak is now root-caused: the `/dev` bind unmount intermittently fails `EBUSY` from
+  shared mount propagation (observed on a real full-system run). Two-part fix — a quick
+  `--make-private` hardening in `scripts/lib/mounts.sh`, plus the actual cleanup trap.
+  - **Plan of attack: `docs/ISSUE_24_CLEANUP_FIX_PLAN.md`** (also references
+    `docs/PRODUCTION_READINESS_REVIEW.md` Critical #2 and the 4 design questions in the
+    issue).
+  - VM with LVM is deployed on fraser (`debian13-vm`) — ready for failure-injection
+    testing. Rebuild/reconnect: see `docs/FRASER_VM_READY.md`.
 - **Queued bug fixes:** #46 (continue backing up to remaining repos when one fails)
   and #57 (verbose output suppressed after remote repo failure). Both are patches.
-- **Next major task: Critical #2 / issue #24** (the LVM cleanup trap).
-  - Background: `docs/PRODUCTION_READINESS_REVIEW.md` (Critical #2) and issue #24
-    itself, which lists 4 open design questions.
-  - Needs a VM with LVM for failure-injection testing: see `dev/vm-builder/`.
+- Issue #55 (warn on mismatched repo names across a volume's locations) shipped in 0.7.0.

--- a/docs/FRASER_VM_READY.md
+++ b/docs/FRASER_VM_READY.md
@@ -1,0 +1,79 @@
+# fraser VM toolchain — ready for use
+
+> **Date:** 2026-07-06
+
+fraser's KVM/Packer/libvirt toolchain is installed and verified. The setup was done in the
+workstation-ops repo; the permanent record lives at
+`workstation-ops/workstations/fraser/vm-dev-tooling.md`.
+
+## What's ready
+
+- **Storage split:** Packer build output (temporary, ~30 GB) stays in the project tree under
+  `/data/git` — standard `output-<builder>/` convention, `.gitignore`d. Deployed VM disks go to
+  the default libvirt pool at `/var/lib/libvirt/images` (on root VG, ~850 GB free). Build output
+  can be cleaned up after a successful deploy.
+- `/data/git` LV extended to 60 GB (was 20 GB) — room for project source + one active build.
+- Packer 1.15.4, QEMU 10.0.8, libvirt 11.3.0, virt-install 5.0.0, Ansible core 2.19.4.
+- `libvirt,kvm` groups active; `libvirtd` enabled; default network active + autostart.
+- SSH key: `~/.ssh/vm-dev` / `~/.ssh/vm-dev.pub` (ed25519, `vm-dev@fraser`).
+
+## VM status (updated 2026-07-06)
+
+The `debian13-vm` VM is **deployed and running** on fraser. Steps 1-4 below are complete.
+
+### Build / deploy / reconnect
+
+```bash
+# Build (~10-20 min, only needed if image changes)
+cd dev/vm-builder/packer-local
+packer init .          # first time only
+./scripts/build.sh
+
+# Deploy
+cd dev/vm-builder/deploy-local
+sudo ./deploy.sh ../packer-local/output/debian13-local/debian13-local \
+  --ssh-key ~/.ssh/vm-dev.pub
+
+# Wait ~1-2 min for LVM migration + reboot, then:
+sudo virsh domifaddr debian13-vm
+ssh -i ~/.ssh/vm-dev debian@<IP>
+```
+
+### Tear down / redeploy
+
+```bash
+sudo virsh destroy debian13-vm
+sudo virsh undefine debian13-vm --remove-all-storage --nvram
+# Then re-run deploy above
+```
+
+### Build steps completed
+
+1. **Config:** pixi on (default), miniconda off (default), restic on (default) — no env var
+   overrides needed. Implemented upstream in `duanegoodner/vm-builder` PR #4, re-cloned
+   into `dev/vm-builder/` at commit 92656f9.
+2. **Build:** `cd dev/vm-builder/packer-local && packer init . && ./scripts/build.sh`
+3. **Deploy:** `cd dev/vm-builder/deploy-local && sudo ./deploy.sh ... --ssh-key ~/.ssh/vm-dev.pub`
+4. **SSH in:** `ssh -i ~/.ssh/vm-dev debian@<IP>` (get IP via `sudo virsh domifaddr debian13-vm`)
+
+See `dev/vm-builder/README.md` for full build/deploy docs.
+
+## Python env in the VM (decided 2026-07-06): pixi in, miniconda out
+
+Use **pixi** for Python/project env management in the VM — it matches resticlvm's bare-metal dev
+workflow (clone + `pixi install` editable, edit `scripts/lib/*.sh`, test with
+`sudo "$(command -v rlvm)" backup`). **Drop miniconda:** its bare-metal value (an always-on
+non-system-python default shell) is redundant in a disposable VM where system Python is PEP-668
+externally-managed and pixi owns the project env, and it reintroduces the conda-shadows-`python3`
+quirk.
+
+Implemented in vm-builder PR #4: `INSTALL_PIXI` defaults to `true`, `INSTALL_MINICONDA` defaults
+to `false`. Override with env vars if needed (e.g. `INSTALL_MINICONDA=true INSTALL_PIXI=false`).
+
+## Gotchas to know
+
+- Packer plugins (`qemu` + `ansible`) come from `packer init`, not apt.
+- `sudo virsh net-list` (not unprivileged) to see networks.
+- `cloud.debian.org` can be unreliable; Packer is configured with a fallback mirror
+  (`gemmei.ftp.acc.umu.se`). Checksum also points at the fallback.
+- `virsh undefine` requires `--nvram` flag (VM uses UEFI).

--- a/docs/ISSUE_24_CLEANUP_FIX_PLAN.md
+++ b/docs/ISSUE_24_CLEANUP_FIX_PLAN.md
@@ -1,0 +1,115 @@
+# Issue #24 — Cleanup-on-failure: root cause + fix plan
+
+Working plan for [#24](https://github.com/duanegoodner/resticlvm/issues/24) ("Critical: no cleanup
+trap — a mid-run failure leaks the LVM snapshot and bind-mounts"), informed by a real leak observed
+during a full-system backup of `fraser` on 2026-07-05. See also
+[`PRODUCTION_READINESS_REVIEW.md`](PRODUCTION_READINESS_REVIEW.md) (Critical #2).
+
+## Background: two distinct problems
+
+Issue #24 is really two things, and it's worth fixing them as separate PRs:
+
+1. **A specific, intermittent failure mode** — the `/dev` bind unmount fails with `EBUSY` during
+   otherwise-successful `lv_root` teardown, due to **shared mount propagation**. This is the trigger
+   we actually hit. Fix is small and deterministic (**`--make-private`**).
+2. **The structural gap** — there is no cleanup **trap**, so *any* mid-run failure (restic error,
+   snapshot CoW overflow, a mount failure, `Ctrl-C`, OOM) aborts under `set -euo pipefail` before
+   `clean_up_snapshot` runs, leaking the snapshot + bind-mounts. Fix is a real cleanup handler.
+
+`--make-private` removes the most common everyday trigger; the trap is the actual close of #24. Do
+both; neither substitutes for the other.
+
+## Root cause of the observed leak (problem 1)
+
+During the `fraser` backup, every `lv_root` restic repo backed up successfully, then teardown failed:
+
+```
+umount: /tmp/resticlvm-<ts>/vg0_lv0_snapshot_<ts>/dev: target is busy.
+```
+
+Only `/dev` failed — `/proc`, `/sys`, `/etc/resolv.conf`, the SSH-socket bind, and the local-repo
+bind all unmounted cleanly. Diagnosis:
+
+- The chroot binds are created with plain `mount --bind` and **inherit systemd's `shared`
+  propagation** (`findmnt -o TARGET,PROPAGATION` shows `/`, `/dev`, `/proc`, `/sys` all `shared`).
+- Unmounting a shared bind **propagates** to its peer group. The real `/dev` (devtmpfs) peer is busy
+  because desktop processes have device nodes **mmap'd** (`/dev/dri/*`, `/dev/nvidia*`, `/dev/shm`),
+  so the propagated unmount returns `EBUSY`. `/proc`/`/sys` peers aren't held that way, hence
+  `/dev`-specific.
+- It is a **race**: the same config leaked on one run and cleaned up fine on the very next identical
+  run (depends on whether `/dev` is held at the instant of the propagated unmount). More likely on a
+  desktop than a headless box.
+
+Diagnostic gotchas (documented so future debugging doesn't go down the wrong path):
+- `fuser -m <snap>/dev` is misleading — it matches the whole shared devtmpfs superblock and lists
+  host desktop processes using the *real* `/dev`, not processes pinning the bind.
+- `lsof` over the snapshot path returns nothing — consistent with "propagation, not an open fd."
+
+## Fix plan
+
+### Part A — `--make-private` (quick, deterministic)
+
+In the bind-setup helper (`scripts/lib/mounts.sh`, `bind_chroot_essentials_to_mounted_snapshot` —
+confirm exact name/location against current code), detach each bind from propagation immediately
+after creating it:
+
+```bash
+mount --bind /dev  "$snap/dev"  && mount --make-private "$snap/dev"
+mount --bind /proc "$snap/proc" && mount --make-private "$snap/proc"
+mount --bind /sys  "$snap/sys"  && mount --make-private "$snap/sys"
+# ...same for the /etc/resolv.conf and SSH-socket binds
+```
+
+With the binds `private`, teardown can't propagate into the host `/dev`, so the normal `umount`
+won't hit `EBUSY`. This is the standard container-runtime approach. (A weaker alternative is
+`umount -l`/`MNT_DETACH` in cleanup, but that papers over the race rather than removing it.)
+
+**Scope:** `scripts/lib/mounts.sh` (bind setup). Applies to the `lv_root` path (which does the chroot
+binds); confirm whether any non-root path binds `/dev`.
+
+### Part B — cleanup trap (the real #24 fix)
+
+Add a `trap`-based cleanup that unwinds whatever was created, on **every** exit path (success,
+error, signal), in `scripts/lib/backup_lv_root.sh` (and the analogous non-root script). Requirements:
+
+- Register the trap as soon as each resource is created (snapshot LV, mountpoint, each bind, each
+  local-repo bind), and have it idempotently unwind in reverse order: unmount binds → unmount
+  snapshot → `lvremove -y` the snapshot → `rmdir` the temp dir.
+- Must be **idempotent** and safe to run when a resource was never created (guard each step).
+- Must cover the multi-repo loop failure (issue #46 territory): a failing repo currently aborts the
+  loop *and* skips cleanup — the trap fixes the cleanup half regardless of how #46 is resolved.
+- Target the snapshot by its exact timestamped name (never a glob) when calling `lvremove`.
+- Preserve the correct exit code (don't let cleanup mask the original failure).
+
+Open design questions are listed in the GitHub issue (#24 lists 4). Resolve those in the PR
+discussion.
+
+## Testing strategy — in a VM, not on bare metal
+
+Failure injection against real root LVM is unsafe, so this work is done in a disposable Debian+LVM
+KVM VM built from [`dev/vm-builder/`](../dev/vm-builder/) (layout has `vg0-lv_root` with free extents,
+a backup LV, a non-root data LV, and a standard partition). Host tooling setup for fraser is
+documented in `workstation-ops/workstations/fraser/vm-dev-tooling.md`.
+
+- **Part A verification:** run an `lv_root` backup; confirm teardown is clean and `findmnt` shows the
+  chroot binds as `private` during the run.
+- **Part B verification (failure injection):** each of these must leave **no** leaked snapshot/mounts
+  (`sudo lvs | grep snapshot` and `mount | grep resticlvm` empty afterward), and return a non-zero
+  exit code:
+  - kill `restic` mid-backup;
+  - force snapshot CoW overflow (undersize `snapshot_size` + write load);
+  - break a bind/mount step;
+  - `Ctrl-C` / `SIGTERM` mid-run;
+  - a remote-repo failure partway through the multi-repo loop.
+
+## References
+
+- Issue #24 (this plan is mirrored in a comment there).
+- `docs/PRODUCTION_READINESS_REVIEW.md` — Critical #2.
+- Manual recovery when a leak does occur:
+  ```bash
+  SNAP=/tmp/resticlvm-<ts>/vg0_lv0_snapshot_<ts>
+  sudo umount -l "$SNAP/dev"; sudo umount "$SNAP"
+  sudo lvremove -y /dev/<vg>/<snapshot-name>
+  sudo rm -rf "$(dirname "$SNAP")"
+  ```


### PR DESCRIPTION
## Summary
- Add `docs/ISSUE_24_CLEANUP_FIX_PLAN.md` — root cause analysis (shared mount propagation EBUSY) and two-part fix plan (--make-private + cleanup trap)
- Add `docs/FRASER_VM_READY.md` — fraser VM toolchain status, build/deploy/reconnect commands, completed steps, and gotchas
- Update `CLAUDE.md` — #24 is lead task, VM is deployed and ready for failure-injection testing

## Context
These docs were drafted in a previous session (root-cause investigation) and updated in this session after building and deploying the VM. They capture the full context needed to proceed with the #24 implementation.

## Test plan
- [x] Docs are accurate relative to current repo state and deployed VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)