### PR TITLE
fix(mounts): make chroot binds private to prevent EBUSY snapshot leak (#24, Part A)

### DIFF
--- a/src/resticlvm/scripts/lib/mounts.sh
+++ b/src/resticlvm/scripts/lib/mounts.sh
@@ -92,6 +92,8 @@ bind_repo_to_mounted_snapshot() {
     echo "  Chroot repo path: $chroot_repo_full"
     run_or_echo "$dry_run" "mkdir -p $snapshot_mount_point/$chroot_repo_full"
     run_or_echo "$dry_run" "mount --bind $restic_repo $snapshot_mount_point/$chroot_repo_full"
+    # Detach from shared propagation so teardown can't propagate into the host.
+    run_or_echo "$dry_run" "mount --make-private $snapshot_mount_point/$chroot_repo_full"
 }
 
 # Bind /dev, /proc, and /sys into the snapshot to enable minimal chroot.
@@ -101,14 +103,22 @@ bind_chroot_essentials_to_mounted_snapshot() {
     local snapshot_mount_point="$2"
 
     echo "🔧 Preparing chroot environment..."
+    # After each bind, detach it from shared mount propagation with
+    # --make-private. Binds otherwise inherit systemd's `shared` propagation, so
+    # unmounting them at teardown propagates into the host's peer group. The
+    # host /dev (devtmpfs) is often busy (mmap'd device nodes: /dev/dri/*,
+    # /dev/nvidia*), making that propagated unmount fail EBUSY and leak the
+    # snapshot. Making each bind private confines teardown to the snapshot. (#24)
     for path in /dev /proc /sys; do
         run_or_echo "$dry_run" "mount --bind $path $snapshot_mount_point$path"
+        run_or_echo "$dry_run" "mount --make-private $snapshot_mount_point$path"
     done
-    
+
     # Bind /etc/resolv.conf for DNS resolution (needed for remote repos like B2/S3)
     if [ -f /etc/resolv.conf ]; then
         echo "🌐 Binding /etc/resolv.conf for DNS resolution..."
         run_or_echo "$dry_run" "mount --bind /etc/resolv.conf $snapshot_mount_point/etc/resolv.conf"
+        run_or_echo "$dry_run" "mount --make-private $snapshot_mount_point/etc/resolv.conf"
     fi
     
     # Bind SSH agent socket directory if it exists (for remote SFTP repos)
@@ -123,6 +133,7 @@ bind_chroot_essentials_to_mounted_snapshot() {
         # Bind mount the socket directory only if not already mounted
         if ! mountpoint -q "$chroot_socket_dir" 2>/dev/null; then
             run_or_echo "$dry_run" "mount --bind \"$socket_dir\" \"$chroot_socket_dir\""
+            run_or_echo "$dry_run" "mount --make-private \"$chroot_socket_dir\""
         fi
     fi
 }


### PR DESCRIPTION
## What

Detach every chroot bind mount from shared mount propagation by running
`mount --make-private` immediately after each `mount --bind` in
`scripts/lib/mounts.sh` — for `/dev`, `/proc`, `/sys`, `/etc/resolv.conf`, the
SSH-agent socket dir, and the local-repo bind.

## Why

Binds created with `mount --bind` inherit systemd's `shared` propagation, so
unmounting them at teardown propagates into the host's peer group. When the host
`/dev` (devtmpfs) is busy — desktop processes mmap device nodes (`/dev/dri/*`,
`/dev/nvidia*`) — the propagated unmount fails `EBUSY` and leaks the snapshot and
its mounts. This is the root cause of the leak observed during the real fraser
full-system backup on 2026-07-05 (only `/dev` failed; `/proc`, `/sys`,
`resolv.conf`, and the repo bind unmounted cleanly). Making each bind `private`
confines teardown to the snapshot so it can never propagate to the host — the
standard container-runtime approach.

## Scope

- `lv_root` path only — the non-root path (`backup_lv_nonroot.sh`) does not create
  a chroot and has no binds.
- Removes the most common everyday trigger for #24. It does **not** add the
  cleanup trap that covers arbitrary mid-run failures (restic error, CoW
  overflow, Ctrl-C) — that's Part B, following in a separate PR. This PR is a
  partial fix and intentionally does not close #24.

## Verification (in the Debian+LVM dev VM)

- `pixi run lint-sh` clean (no new findings), `pixi run test` 103 passed.
- Dry run: every `mount --bind` is immediately followed by `mount --make-private`
  for all five bind sites, in order.
- Real `lv_root` backup to a local repo: exit 0; live `findmnt` polling caught
  `/dev` transitioning `shared` -> `private` and all binds settling at `private`;
  no leaked snapshot LVs and no leaked `resticlvm` mounts after teardown.

Note: the VM is headless, so it does not *reproduce* the desktop `/dev` EBUSY
race; the real-run test confirms no regression and that the binds are genuinely
private. The EBUSY reproduction relies on a desktop holding device nodes.

Refs #24 (Part A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
