### PR TITLE
docs: update stale backup.toml examples to the current schema

### DIFF
--- a/docs/EXAMPLE_B2_SETUP.md
+++ b/docs/EXAMPLE_B2_SETUP.md
@@ -186,43 +186,48 @@ created restic repository abc123def at s3:s3.us-west-004...
 ```toml
 # /etc/resticlvm/backup.toml
 
-[logical_volume_root.root]
+[prune_policy.cloud]
+keep_last = 60
+keep_daily = 60
+keep_weekly = 24
+keep_monthly = 36
+keep_yearly = 10
+
+[volume.root]
+volume_type = "lv_root"
 vg_name = "vg0"
 lv_name = "lv_root"
 snapshot_size = "2G"
 backup_source_path = "/"
 exclude_paths = ["/dev", "/proc", "/sys", "/tmp"]
 
-[[logical_volume_root.root.repositories]]
+[[volume.root.repositories]]
 repo_path = "s3:s3.us-west-004.backblazeb2.com/mycompany-backups/resticlvm/root"
 password_file = "/etc/resticlvm/restic-password.txt"
-prune_keep_last = 60
-prune_keep_daily = 60
-prune_keep_weekly = 24
-prune_keep_monthly = 36
-prune_keep_yearly = 10
+prune_policy = "cloud"
 ```
 
 ### Example: Local + Copy to B2 (Recommended)
 
 ```toml
-[[logical_volume_root.root.repositories]]
+# [prune_policy.cloud] is defined in the direct-backup example above; add a
+# "local" retention policy for the on-disk repository:
+[prune_policy.local]
+keep_last = 7
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 3
+keep_yearly = 1
+
+[[volume.root.repositories]]
 repo_path = "/backups/root-local"
 password_file = "/etc/resticlvm/restic-password.txt"
-prune_keep_last = 7
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 3
-prune_keep_yearly = 1
+prune_policy = "local"
 
-  [[logical_volume_root.root.repositories.copy_to]]
+  [[volume.root.repositories.copy_to]]
   repo = "s3:s3.us-west-004.backblazeb2.com/mycompany-backups/resticlvm/root"
   password_file = "/etc/resticlvm/restic-password.txt"
-  prune_keep_last = 60
-  prune_keep_daily = 60
-  prune_keep_weekly = 24
-  prune_keep_monthly = 36
-  prune_keep_yearly = 10
+  prune_policy = "cloud"
 ```
 
 ---

--- a/docs/EXAMPLE_SSH_SETUP.md
+++ b/docs/EXAMPLE_SSH_SETUP.md
@@ -306,7 +306,15 @@ sudo root-ssh-agent ssh-add /root/.ssh/id_restic_backup
 In your ResticLVM config (`backup.toml`):
 
 ```toml
-[logical_volume_root.root]
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
+[volume.root]
+volume_type = "lv_root"
 vg_name = "vg0"
 lv_name = "lv_root"
 snapshot_size = "2G"
@@ -314,14 +322,16 @@ backup_source_path = "/"
 exclude_paths = ["/dev", "/proc", "/sys", "/tmp"]
 
 # Local repository
-[[logical_volume_root.root.repositories]]
+[[volume.root.repositories]]
 repo_path = "/srv/backup/root-local"
 password_file = "/etc/resticlvm/restic-password.txt"
+prune_policy = "standard"
 
 # Remote SFTP repository (dedicated user)
-[[logical_volume_root.root.repositories]]
+[[volume.root.repositories]]
 repo_path = "sftp:backup-clienthost@backup-server.example.com:/srv/client_backups/clienthost/root"
 password_file = "/etc/resticlvm/restic-password.txt"
+prune_policy = "standard"
 ```
 
 ## Additional Hardening (Optional)

--- a/src/resticlvm/scripts/lib/mounts.sh
+++ b/src/resticlvm/scripts/lib/mounts.sh
@@ -42,7 +42,7 @@ remount_as_read_only() {
             echo "   Device: $dev"
             echo ""
             echo "   → Set 'remount_readonly = false' in your configuration."
-            echo "   → Consider using 'logical_volume_root' type for root filesystem backups."
+            echo "   → Consider using 'lv_root' volume_type for root filesystem backups."
             exit 1
         fi
         

--- a/test/test_backup_runner.py
+++ b/test/test_backup_runner.py
@@ -95,8 +95,8 @@ def test_run_all_respects_category_and_name_filters():
     """Filtered-out jobs are not run."""
     a = _fake_job("standard_path", "a",
                   JobResult("standard_path", "a", script_ok=True, failed_copies=[]))
-    b = _fake_job("logical_volume_root", "b",
-                  JobResult("logical_volume_root", "b", script_ok=True, failed_copies=[]))
+    b = _fake_job("lv_root", "b",
+                  JobResult("lv_root", "b", script_ok=True, failed_copies=[]))
 
     BackupJobRunner([a, b]).run_all(category="standard_path")
 

--- a/tools/b2/README.md
+++ b/tools/b2/README.md
@@ -179,14 +179,22 @@ source /root/.config/resticlvm/b2-env
 Add B2 repositories to your ResticLVM config file (e.g., `backup-config.toml`):
 
 ```toml
-[[standard_path.boot.repositories]]
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+
+[volume.boot]
+volume_type = "standard_path"
+backup_source_path = "/boot"
+exclude_paths = []
+
+[[volume.boot.repositories]]
 repo_path = "s3:s3.us-west-004.backblazeb2.com/kernelstate-backups/resticlvm/rudolph/boot-01"
 password_file = "/root/.config/resticlvm/repo-creds/b2-boot-01.txt"
-prune_keep_last = 10
-prune_keep_daily = 7
-prune_keep_weekly = 4
-prune_keep_monthly = 6
-prune_keep_yearly = 1
+prune_policy = "standard"
 ```
 
 ## Cron Setup


### PR DESCRIPTION
## What

Repo-wide sweep to fix `backup.toml` examples that used an **outdated schema
that no longer parses**. Surfaced while setting up config for the #24
failure-injection testing — the old examples produced "0 jobs" or
`KeyError: 'prune_policy'`.

## Stale patterns fixed

- Old per-category section headers — `[logical_volume_root.root]`,
  `[[standard_path.boot.repositories]]` — replaced with the current
  `[volume.<name>]` + `volume_type = "..."` form.
- Inline `prune_keep_*` keys on repositories — replaced with
  `prune_policy = "<name>"` referencing a `[prune_policy.<name>]` block.

## Files

- `docs/EXAMPLE_SSH_SETUP.md`, `docs/EXAMPLE_B2_SETUP.md`, `tools/b2/README.md`
  — rewrote the config examples to the current schema.
- `src/resticlvm/scripts/lib/mounts.sh` — a user-facing hint named the old
  `'logical_volume_root'` type; now `'lv_root'`.
- `test/test_backup_runner.py` — use the real `lv_root` category label
  instead of the stale `logical_volume_root` string.

`README.md` already used the current schema (unchanged). The `CHANGELOG`
entry documenting the old->new migration is intentionally left as history.

## Verification

- Extracted every ```` ```toml ```` example block from the changed docs and
  parsed each complete config through the real `BackupConfigFactory` — all
  parse and resolve volumes/repos/copy_to correctly.
- `pixi run test` 103 passed; `pixi run lint-sh` clean.