### PR TITLE
fix(cleanup): idempotent cleanup-on-failure trap for LVM snapshots (#24)

### DIFF
--- a/src/resticlvm/scripts/backup_lv_nonroot.sh
+++ b/src/resticlvm/scripts/backup_lv_nonroot.sh
@@ -98,6 +98,9 @@ display_dry_run_message "$DRY_RUN"
 
 # ─── Create and Mount Snapshot ────────────────────────────────────
 create_snapshot "$DRY_RUN" "$SNAPSHOT_SIZE" "$SNAP_NAME" "$VG_NAME" "$LV_NAME"
+# Register cleanup-on-failure as soon as the snapshot exists so any later
+# failure/signal idempotently unwinds the snapshot and its mount (issue #24).
+install_snapshot_cleanup_trap
 mount_snapshot "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$VG_NAME" "$SNAP_NAME"
 
 # ─── Build Exclude Arguments (Once) ───────────────────────────────

--- a/src/resticlvm/scripts/backup_lv_root.sh
+++ b/src/resticlvm/scripts/backup_lv_root.sh
@@ -89,6 +89,9 @@ display_dry_run_message "$DRY_RUN"
 
 # ─── Create Snapshot and Mount ────────────────────────────────────
 create_snapshot "$DRY_RUN" "$SNAPSHOT_SIZE" "$SNAP_NAME" "$VG_NAME" "$LV_NAME"
+# Register cleanup-on-failure as soon as the snapshot exists so any later
+# failure/signal idempotently unwinds the snapshot and its mounts (issue #24).
+install_snapshot_cleanup_trap
 mount_snapshot "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$VG_NAME" "$SNAP_NAME"
 
 # ─── Prepare Chroot Environment ───────────────────────────────────

--- a/src/resticlvm/scripts/lib/lv_snapshots.sh
+++ b/src/resticlvm/scripts/lib/lv_snapshots.sh
@@ -65,3 +65,106 @@ generate_mount_base() {
     timestamp=$(date +"%Y%m%d_%H%M%S")
     echo "/tmp/resticlvm-${timestamp}"
 }
+
+# ─── Cleanup-on-failure (issue #24) ───────────────────────────────
+#
+# Idempotent, best-effort teardown of a snapshot and everything mounted under
+# it. Safe to call when nothing (or only part) of it was created, and safe to
+# call more than once. Every step is guarded and ignores its own errors, so it
+# never masks the caller's exit code. Uses the discover-and-tear-down approach:
+# it finds whatever is mounted under the snapshot rather than tracking binds.
+cleanup_snapshot_resources() {
+    local snapshot_mount_point="$1"
+    local mount_base="$2"
+    local vg_name="$3"
+    local snap_name="$4"
+
+    if [ -n "$snapshot_mount_point" ]; then
+        # Unmount anything bound under the snapshot (chroot binds + the per-repo
+        # bind), deepest path first so parents unmount last. umount -l is the
+        # fallback for a still-busy target.
+        local target
+        while IFS= read -r target; do
+            [ "$target" = "$snapshot_mount_point" ] && continue
+            umount "$target" 2>/dev/null \
+                || umount -l "$target" 2>/dev/null || true
+        done < <(findmnt -rn -o TARGET 2>/dev/null \
+            | awk -v base="$snapshot_mount_point/" 'index($0, base) == 1' \
+            | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2-)
+
+        # Unmount the snapshot itself. Prefer a real unmount (retried briefly)
+        # over a lazy one: a lazy detach can leave the device transiently busy
+        # and then race the lvremove below.
+        if mountpoint -q "$snapshot_mount_point" 2>/dev/null; then
+            local u=0
+            until umount "$snapshot_mount_point" 2>/dev/null; do
+                u=$((u + 1))
+                if [ "$u" -ge 5 ]; then
+                    umount -l "$snapshot_mount_point" 2>/dev/null || true
+                    break
+                fi
+                sleep 0.3
+            done
+        fi
+    fi
+
+    # Remove the snapshot LV by its exact, timestamped name (never a glob),
+    # regardless of whether the unmounts above fully succeeded. After a process
+    # (e.g. restic) has read the mounted snapshot, the device can stay briefly
+    # busy once unmounted, so let udev settle and retry lvremove for a few
+    # seconds rather than giving up after one attempt.
+    if [ -n "$vg_name" ] && [ -n "$snap_name" ] \
+        && lvs "/dev/$vg_name/$snap_name" >/dev/null 2>&1; then
+        command -v udevadm >/dev/null 2>&1 && udevadm settle >/dev/null 2>&1 || true
+        local r=0
+        while lvs "/dev/$vg_name/$snap_name" >/dev/null 2>&1; do
+            lvremove -f "/dev/$vg_name/$snap_name" >/dev/null 2>&1 && break
+            r=$((r + 1))
+            [ "$r" -ge 10 ] && break
+            sleep 0.3
+        done
+    fi
+
+    # Remove the mount point, any now-empty parents, and the temp base dir.
+    # Bounded at mount_base so this never climbs into /tmp or above, and rmdir
+    # only removes empty dirs so a still-populated path is left untouched.
+    if [ -n "$snapshot_mount_point" ] && [ -n "$mount_base" ]; then
+        local dir="$snapshot_mount_point"
+        while [ -n "$dir" ] && [ "$dir" != "$mount_base" ] && [ "$dir" != "/" ]; do
+            rmdir "$dir" 2>/dev/null || break
+            dir=$(dirname "$dir")
+        done
+        rmdir "$mount_base" 2>/dev/null || true
+    fi
+}
+
+# EXIT/signal trap handler. Preserves the original exit code, disarms itself to
+# avoid re-entry, and skips real teardown in dry-run mode. Reads the well-known
+# globals set by the backup scripts (SNAPSHOT_MOUNT_POINT, MOUNT_BASE, VG_NAME,
+# SNAP_NAME, DRY_RUN).
+# shellcheck disable=SC2154
+_snapshot_cleanup_trap() {
+    local rc=$?
+    trap - EXIT INT TERM HUP
+    if [ "${DRY_RUN:-false}" != true ]; then
+        if [ "$rc" -ne 0 ]; then
+            echo "" >&2
+            echo "⚠️  Backup aborted (exit $rc) — releasing LVM snapshot and mounts…" >&2
+        fi
+        cleanup_snapshot_resources \
+            "${SNAPSHOT_MOUNT_POINT:-}" "${MOUNT_BASE:-}" \
+            "${VG_NAME:-}" "${SNAP_NAME:-}"
+    fi
+    exit "$rc"
+}
+
+# Install the cleanup trap on every exit path (normal, error, signal). Call this
+# immediately after the snapshot is created. Signal traps re-exit with a
+# conventional 128+signo code, which routes through the EXIT trap so cleanup
+# runs exactly once.
+install_snapshot_cleanup_trap() {
+    trap '_snapshot_cleanup_trap' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    trap 'exit 129' HUP
+}


### PR DESCRIPTION
## What

Closes the structural half of #24: register an idempotent cleanup **trap** so a
mid-run failure can no longer leak the LVM snapshot and its bind-mounts. Part A
(#65, `--make-private`) removed the most common everyday *trigger*; this is the
actual fix.

Previously, under `set -euo pipefail`, any mid-run failure — a restic error,
snapshot CoW overflow, a failed mount/bind, or `Ctrl-C`/`SIGTERM` — aborted
before the end-of-script cleanup ran, leaking the snapshot + mounts.

## Approach

New helpers in `scripts/lib/lv_snapshots.sh`:

- **`cleanup_snapshot_resources()`** — idempotent, best-effort teardown, using a
  **discover-and-tear-down** strategy: enumerate everything mounted under the
  snapshot mount point (chroot binds + the per-repo bind) via `findmnt` and
  unmount deepest-first (real `umount` retried briefly, then `umount -l`
  fallback), unmount the snapshot, then `lvremove -f` the **exact** timestamped
  snapshot name (never a glob), then `rmdir` the mount point + temp base
  (bounded at `MOUNT_BASE`, empty-only). Every step is guarded and swallows its
  own errors so it never masks the caller's exit code.
- **`install_snapshot_cleanup_trap()`** — registers the cleanup on `EXIT` and on
  `INT`/`TERM`/`HUP` (signals re-exit `128+signo`, routed through `EXIT` so
  cleanup runs exactly once), preserves the original exit code, disarms on entry
  to avoid re-entry, and is a no-op under `--dry-run`.

Wired into `backup_lv_root.sh` and `backup_lv_nonroot.sh` immediately after
`create_snapshot`.

### Design decisions (issue's 4 open questions)

1. **Option A** — keep the existing ordered happy-path teardown as primary; the
   trap is an idempotent safety net. On success it's a quiet no-op that also
   sweeps the previously-leaked empty `/tmp/resticlvm-<ts>` dir. Bonus: it now
   also backstops a happy-path `umount`/`lvremove` that hits the transient-busy
   race below.
2. **Discover & tear down** (via `findmnt`) rather than track & reverse — no
   bookkeeping across the multi-repo loop, inherently idempotent.
3. **`${SSH_AUTH_SOCK:-}`** default fix deferred — every use is already guarded;
   nothing to change here.
4. Verification: VM failure-injection (below).

### Transient-busy hardening

After a reader (restic) has used the mounted snapshot, the device can stay
briefly busy once unmounted, so a single `lvremove` can fail while a retry a
moment later succeeds. The cleanup therefore `udevadm settle`s and **retries
`lvremove` for a few seconds**, and prefers a retried real `umount` over an
immediate lazy detach. (Caught by scenario 1 below during testing.)

## Verification

In a disposable Debian+LVM VM, root path, each scenario asserts **non-zero exit
and zero leaked snapshot LVs / mounts / temp dirs**:

| Scenario | Result |
| --- | --- |
| restic fails mid-run (wrong password, after binds) | PASS |
| bind step fails (nonexistent repo) | PASS |
| restic SIGKILLed mid-backup | PASS |
| SIGTERM to backup script mid-run | PASS |
| SIGINT (Ctrl-C) mid-run | PASS |
| control run (happy path) | succeeds, no leaks |

The **nonroot** path (throwaway LV mounted off-root) was exercised the same way
— restic fails mid-run, restic SIGKILLed, and SIGTERM to the script — all PASS,
including cleanup of the nested `/tmp/resticlvm-<ts>/<mnt>` mount point, plus a
clean control run.

Plus non-root unit checks of exit-code preservation (success/fail/dry-run),
signal routing (INT=130, TERM=143, cleanup runs immediately or deferred until
the current foreground command returns), idempotency, and bounded/empty-only dir
removal. `shellcheck` clean; 103 tests pass.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)