### PR TITLE
docs: add LVM snapshot cleanup failure-injection harness + runbook

### DIFF
--- a/dev/failure-injection/_common.sh
+++ b/dev/failure-injection/_common.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Shared helpers for the resticlvm failure-injection harness (issue #24).
+# Sourced by verify_root.sh / verify_nonroot.sh — not run directly.
+#
+# These scripts prove that a mid-run failure leaves NO leaked LVM snapshot,
+# NO leftover bind/snapshot mount, and NO stray temp dir, and that rlvm still
+# exits non-zero. See docs/FAILURE_INJECTION_TESTING.md for the full runbook.
+
+# rlvm entrypoint. sudo scrubs PATH, so the verify scripts take it as $1 (or set
+# RLVM). Pin the absolute path, e.g. RLVM="$(command -v rlvm)".
+: "${RLVM:=}"
+
+# Environment defaults — override via env vars to match your VM/setup.
+: "${VG:=vg0}"                                  # volume group holding the LV
+: "${PW:=/etc/resticlvm/restic-password.txt}"   # restic password file
+
+# Scratch dir for generated configs. NOTE: deliberately NOT under a
+# /tmp/resticlvm-* path, so it can never be mistaken for a leaked snapshot dir.
+# Kept after the run so the printed control-run command still works; prior
+# workdirs are swept here on each start.
+rm -rf "${TMPDIR:-/tmp}"/rlvm-fi.* 2>/dev/null || true
+# shellcheck disable=SC2034  # consumed by the scripts that source this file
+FI_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/rlvm-fi.XXXXXX")"
+
+fi_pass=0
+fi_fail=0
+
+# Emit a [prune_policy.standard] block usable by any generated config.
+fi_prune_block() {
+    cat <<'EOF'
+[prune_policy.standard]
+keep_last = 10
+keep_daily = 7
+keep_weekly = 4
+keep_monthly = 6
+keep_yearly = 1
+EOF
+}
+
+# Remove stale, always-empty /tmp/resticlvm-* dirs from earlier runs so leak
+# counts reflect only the current run.
+fi_clean_stale_tmp() {
+    local n
+    n=$(find /tmp -maxdepth 1 -name 'resticlvm-*' -type d 2>/dev/null | wc -l)
+    if [ "$n" -gt 0 ]; then
+        echo "ℹ️  Removing $n stale /tmp/resticlvm-* dir(s) before starting."
+        rm -rf /tmp/resticlvm-* 2>/dev/null || true
+    fi
+}
+
+# Wait until a process literally named "restic" is running (so injection hits
+# an in-progress backup). $1 = timeout in deciseconds (default 200 = 20s).
+wait_for_restic() {
+    local i=0
+    while ! pgrep -x restic >/dev/null 2>&1; do
+        i=$((i + 1))
+        [ "$i" -ge "${1:-200}" ] && return 1
+        sleep 0.1
+    done
+}
+
+# Assert clean teardown. $1 = scenario name, $2 = observed rlvm exit code.
+# IMPORTANT: kill restic by exact name (pkill -x restic), never `pkill -f
+# restic`: the backup script's own cmdline contains "restic-password.txt" and
+# the repo path, so an -f pattern would SIGKILL the (untrappable) script and
+# manufacture a false leak.
+check_clean() {
+    local name="$1" rc="$2" snaps mounts dirs
+    snaps=$(lvs --noheadings -o lv_name "$VG" 2>/dev/null | grep -c '_snapshot_')
+    mounts=$(mount 2>/dev/null | grep -c '/tmp/resticlvm-')
+    dirs=$(find /tmp -maxdepth 1 -name 'resticlvm-*' -type d 2>/dev/null | wc -l)
+    echo "  ── $name ──"
+    echo "     rlvm exit code  : $rc  ($([ "$rc" -ne 0 ] && echo non-zero OK || echo 'ZERO — unexpected'))"
+    echo "     snapshot LVs    : $snaps  ($([ "$snaps" -eq 0 ] && echo OK || echo LEAK))"
+    echo "     resticlvm mounts: $mounts  ($([ "$mounts" -eq 0 ] && echo OK || echo LEAK))"
+    echo "     temp dirs       : $dirs  ($([ "$dirs" -eq 0 ] && echo OK || echo LEAK))"
+    [ "$dirs" -ne 0 ] && find /tmp -maxdepth 1 -name 'resticlvm-*' -type d 2>/dev/null | sed 's/^/       /'
+    if [ "$rc" -ne 0 ] && [ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ]; then
+        echo "     RESULT: PASS"
+        fi_pass=$((fi_pass + 1))
+    else
+        echo "     RESULT: FAIL"
+        fi_fail=$((fi_fail + 1))
+        # best-effort manual cleanup so the next scenario starts clean
+        mount | awk '/\/tmp\/resticlvm-/ {print $3}' | sort -r | xargs -r -n1 umount -l 2>/dev/null
+        lvs --noheadings -o lv_name "$VG" 2>/dev/null | grep '_snapshot_' \
+            | xargs -r -n1 -I{} lvremove -f "/dev/$VG/{}" 2>/dev/null
+        rm -rf /tmp/resticlvm-* 2>/dev/null
+    fi
+}
+
+fi_summary() {
+    echo
+    echo "════════ $1: $fi_pass passed, $fi_fail failed ════════"
+    [ "$fi_fail" -eq 0 ]
+}
+
+fi_require_rlvm() {
+    if [ -z "$RLVM" ]; then
+        echo "❌ Pass the rlvm path as the first argument (sudo scrubs PATH):" >&2
+        echo "   sudo bash $0 \"\$(command -v rlvm)\"" >&2
+        exit 2
+    fi
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "❌ Must run as root (LVM snapshot + chroot)." >&2
+        exit 2
+    fi
+}

--- a/dev/failure-injection/setup_nonroot.sh
+++ b/dev/failure-injection/setup_nonroot.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Create a disposable non-root LVM volume for nonroot failure-injection. Run as
+# root. Remove afterward with teardown_nonroot.sh.
+#
+# Env overrides (defaults suit the dev VM):
+#   VG=vg0  LV=lv_testdata  MNT=/mnt/testdata
+#   REPO=/srv/backup/testdata-local  PW=/etc/resticlvm/restic-password.txt
+# Requires free extents in $VG (for the LV + its snapshot at verify time).
+set -euo pipefail
+
+: "${VG:=vg0}"
+: "${LV:=lv_testdata}"
+: "${MNT:=/mnt/testdata}"
+: "${REPO:=/srv/backup/testdata-local}"
+: "${PW:=/etc/resticlvm/restic-password.txt}"
+
+echo "📦 Creating ${VG}/${LV} (1G) ..."
+lvcreate -y -L 1G -n "$LV" "$VG"
+mkfs.ext4 -q "/dev/$VG/$LV"
+mkdir -p "$MNT"
+mount "/dev/$VG/$LV" "$MNT"
+
+echo "🧾 Writing ~200 MiB of payload so restic runs long enough to interrupt ..."
+mkdir -p "$MNT/payload"
+dd if=/dev/urandom of="$MNT/payload/blob" bs=1M count=200 status=none
+for i in $(seq 1 200); do head -c 4096 /dev/urandom > "$MNT/payload/f_$i"; done
+sync
+
+echo "🔐 Initializing restic repo $REPO ..."
+if ! restic -r "$REPO" --password-file "$PW" cat config >/dev/null 2>&1; then
+    restic -r "$REPO" --password-file "$PW" init
+else
+    echo "   (repo already exists — reusing)"
+fi
+
+echo "✅ Nonroot test volume ready: $VG/$LV mounted at $MNT, repo at $REPO"

--- a/dev/failure-injection/teardown_nonroot.sh
+++ b/dev/failure-injection/teardown_nonroot.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Remove the disposable nonroot test volume + repo created by setup_nonroot.sh.
+# Run as root. Env overrides must match setup_nonroot.sh.
+set -uo pipefail
+
+: "${VG:=vg0}"
+: "${LV:=lv_testdata}"
+: "${MNT:=/mnt/testdata}"
+: "${REPO:=/srv/backup/testdata-local}"
+
+# sweep any leftover snapshot of the test LV first
+lvs --noheadings -o lv_name "$VG" 2>/dev/null | grep '_snapshot_' \
+    | xargs -r -n1 -I{} lvremove -f "/dev/$VG/{}" 2>/dev/null || true
+
+umount "$MNT" 2>/dev/null || true
+lvremove -f "/dev/$VG/$LV" 2>/dev/null || true
+rmdir "$MNT" 2>/dev/null || true
+rm -rf "$REPO" 2>/dev/null || true
+echo "✅ Nonroot test volume/repo removed."

--- a/dev/failure-injection/verify_nonroot.sh
+++ b/dev/failure-injection/verify_nonroot.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Failure-injection verification — NONROOT path (lv_nonroot, no chroot). Run as
+# root, after setup_nonroot.sh.
+#   sudo bash verify_nonroot.sh "$(command -v rlvm)"
+#
+# Env overrides must match setup_nonroot.sh:
+#   VG=vg0  LV=lv_testdata  MNT=/mnt/testdata  REPO=/srv/backup/testdata-local
+set -uo pipefail
+
+RLVM="${1:-${RLVM:-}}"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/_common.sh"
+fi_require_rlvm
+
+: "${LV:=lv_testdata}"
+: "${MNT:=/mnt/testdata}"
+: "${REPO:=/srv/backup/testdata-local}"
+
+fi_clean_stale_tmp
+
+GOOD="$FI_WORKDIR/good_nonroot.toml"
+BADPASS="$FI_WORKDIR/badpass_nonroot.toml"
+WRONGPW="$FI_WORKDIR/wrong-password.txt"
+
+{
+    fi_prune_block
+    cat <<EOF
+
+[volume.testdata]
+volume_type = "lv_nonroot"
+vg_name = "$VG"
+lv_name = "$LV"
+snapshot_size = "512M"
+backup_source_path = "$MNT"
+exclude_paths = []
+
+[[volume.testdata.repositories]]
+repo_path = "$REPO"
+password_file = "$PW"
+prune_policy = "standard"
+EOF
+} > "$GOOD"
+
+echo 'definitely-the-wrong-password' > "$WRONGPW"
+sed "s#password_file = \"$PW\"#password_file = \"$WRONGPW\"#" "$GOOD" > "$BADPASS"
+
+# 1: restic fails mid-run (wrong password)
+"$RLVM" backup --config "$BADPASS" >/dev/null 2>&1
+check_clean "restic fails mid-run (wrong password)" "$?"
+
+# 2: kill restic mid-backup (SIGKILL, exact process name)
+"$RLVM" backup --config "$GOOD" >/dev/null 2>&1 &
+BPID=$!
+if wait_for_restic 200; then sleep 0.3; pkill -9 -x restic 2>/dev/null; fi
+wait "$BPID"; check_clean "kill restic mid-backup (SIGKILL)" "$?"
+
+# 3: SIGTERM to the nonroot backup script mid-run
+"$RLVM" backup --config "$GOOD" >/dev/null 2>&1 &
+BPID=$!
+if wait_for_restic 200; then sleep 0.3; pkill -TERM -f 'backup_lv_nonroot\.sh' 2>/dev/null; sleep 0.2; pkill -9 -x restic 2>/dev/null; fi
+wait "$BPID"; check_clean "SIGTERM to nonroot backup script" "$?"
+
+echo "(control run should still SUCCEED cleanly:  sudo $RLVM backup --config $GOOD )"
+fi_summary "Nonroot-path failure-injection"

--- a/dev/failure-injection/verify_root.sh
+++ b/dev/failure-injection/verify_root.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Failure-injection verification — ROOT path (lv_root, chroot binds). Run as root.
+#   sudo bash verify_root.sh "$(command -v rlvm)"
+#
+# Env overrides (defaults suit the dev VM):
+#   VG=vg0  LV=lv_root  REPO=/srv/backup/root-local
+#   PW=/etc/resticlvm/restic-password.txt
+# Prereqs: the LV is mounted at / and REPO is an initialized restic repo.
+set -uo pipefail
+
+RLVM="${1:-${RLVM:-}}"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/_common.sh"
+fi_require_rlvm
+
+: "${LV:=lv_root}"
+: "${REPO:=/srv/backup/root-local}"
+
+fi_clean_stale_tmp
+
+GOOD="$FI_WORKDIR/good.toml"
+BADPASS="$FI_WORKDIR/badpass.toml"
+BADREPO="$FI_WORKDIR/badrepo.toml"
+WRONGPW="$FI_WORKDIR/wrong-password.txt"
+
+{
+    fi_prune_block
+    cat <<EOF
+
+[volume.root]
+volume_type = "lv_root"
+vg_name = "$VG"
+lv_name = "$LV"
+snapshot_size = "2G"
+backup_source_path = "/"
+exclude_paths = ["/dev", "/proc", "/sys", "/tmp", "$(dirname "$REPO")"]
+
+[[volume.root.repositories]]
+repo_path = "$REPO"
+password_file = "$PW"
+prune_policy = "standard"
+EOF
+} > "$GOOD"
+
+echo 'definitely-the-wrong-password' > "$WRONGPW"
+sed "s#password_file = \"$PW\"#password_file = \"$WRONGPW\"#" "$GOOD" > "$BADPASS"
+sed "s#repo_path = \"$REPO\"#repo_path = \"$(dirname "$REPO")/does-not-exist\"#" "$GOOD" > "$BADREPO"
+
+# 1: restic fails mid-run (wrong password) — fails AFTER all binds are set up
+"$RLVM" backup --config "$BADPASS" >/dev/null 2>&1
+check_clean "restic fails mid-run (wrong password)" "$?"
+
+# 2: bind step fails (nonexistent local repo → mount --bind fails)
+"$RLVM" backup --config "$BADREPO" >/dev/null 2>&1
+check_clean "bind step fails (nonexistent repo)" "$?"
+
+# 3: kill restic mid-backup (SIGKILL, exact process name)
+"$RLVM" backup --config "$GOOD" >/dev/null 2>&1 &
+BPID=$!
+if wait_for_restic 200; then sleep 0.3; pkill -9 -x restic 2>/dev/null; fi
+wait "$BPID"; check_clean "kill restic mid-backup (SIGKILL)" "$?"
+
+# 4: SIGTERM to the backup script mid-run (arm trap, then unblock restic)
+"$RLVM" backup --config "$GOOD" >/dev/null 2>&1 &
+BPID=$!
+if wait_for_restic 200; then sleep 0.3; pkill -TERM -f 'backup_lv_root\.sh' 2>/dev/null; sleep 0.2; pkill -9 -x restic 2>/dev/null; fi
+wait "$BPID"; check_clean "SIGTERM to backup script mid-run" "$?"
+
+# 5: SIGINT (Ctrl-C emulation) to the backup script mid-run
+"$RLVM" backup --config "$GOOD" >/dev/null 2>&1 &
+BPID=$!
+if wait_for_restic 200; then sleep 0.3; pkill -INT -f 'backup_lv_root\.sh' 2>/dev/null; sleep 0.2; pkill -9 -x restic 2>/dev/null; fi
+wait "$BPID"; check_clean "SIGINT (Ctrl-C) to backup script mid-run" "$?"
+
+echo "(control run should still SUCCEED cleanly:  sudo $RLVM backup --config $GOOD )"
+fi_summary "Root-path failure-injection"

--- a/docs/FAILURE_INJECTION_TESTING.md
+++ b/docs/FAILURE_INJECTION_TESTING.md
@@ -1,0 +1,105 @@
+# Failure-injection testing for LVM snapshot cleanup
+
+A runbook for proving that a **mid-run failure leaves nothing behind** — no
+leaked LVM snapshot, no leftover bind/snapshot mount, no stray temp dir — and
+that `rlvm` still exits non-zero. This is the harness that verified the issue
+[#24](https://github.com/duanegoodner/resticlvm/issues/24) cleanup trap, kept
+around because it's the natural regression check for any future change to the
+snapshot create/mount/teardown path (e.g. the multi-repo failure handling in
+#46/#57).
+
+The runnable scripts live in [`dev/failure-injection/`](../dev/failure-injection/).
+
+> **Run this in a disposable VM, never on a real system.** Failure injection
+> against live root LVM is unsafe. Use the Debian+LVM dev VM — see
+> [`FRASER_VM_READY.md`](FRASER_VM_READY.md).
+
+## What it checks
+
+After each injected failure the harness asserts all of:
+
+- `rlvm` exit code is **non-zero**;
+- **0** snapshot LVs remain (`lvs | grep _snapshot_`);
+- **0** `resticlvm` mounts remain (`mount | grep /tmp/resticlvm-`);
+- **0** leftover temp dirs remain (`/tmp/resticlvm-*`).
+
+## Prerequisites
+
+- Root (LVM snapshot + chroot).
+- `rlvm` installed. `sudo` scrubs `PATH`, so pass its absolute path as the first
+  argument: `sudo bash verify_root.sh "$(command -v rlvm)"`.
+- **Root path:** the target LV is mounted at `/`, and an initialized restic repo
+  + password file exist. Defaults: `VG=vg0`, `LV=lv_root`,
+  `REPO=/srv/backup/root-local`, `PW=/etc/resticlvm/restic-password.txt` —
+  override via env vars.
+- **Nonroot path:** free extents in `VG` (the harness creates a throwaway 1G LV
+  and its snapshot). `setup_nonroot.sh` handles LV/fs/mount/payload/repo.
+
+## Running it
+
+Root path (5 scenarios):
+
+```bash
+sudo bash dev/failure-injection/verify_root.sh "$(command -v rlvm)"
+```
+
+Nonroot path (throwaway LV; 3 scenarios):
+
+```bash
+sudo bash dev/failure-injection/setup_nonroot.sh
+sudo bash dev/failure-injection/verify_nonroot.sh "$(command -v rlvm)"
+sudo bash dev/failure-injection/teardown_nonroot.sh          # when done
+```
+
+Each verify script prints a per-scenario table and a final `N passed, M failed`
+summary (exit 0 iff all passed), and prints a control-run command using a
+generated good config so you can confirm the happy path still succeeds cleanly.
+
+## Scenarios
+
+| Scenario | Path | How it's injected |
+| --- | --- | --- |
+| restic fails mid-run | root + nonroot | a repo with a wrong password file — restic fails *after* binds/mount are set up |
+| bind step fails | root | a nonexistent local repo path → `mount --bind` fails |
+| restic killed mid-backup | root + nonroot | `pkill -9 -x restic` once a backup is in progress |
+| SIGTERM to the backup script | root + nonroot | `pkill -TERM -f backup_lv_*.sh`, then kill restic to unblock |
+| SIGINT (Ctrl-C emulation) | root | `pkill -INT -f backup_lv_root.sh`, then kill restic to unblock |
+
+The nonroot path additionally exercises **nested** mount-point cleanup
+(`/tmp/resticlvm-<ts>/mnt/<...>`), which the root path (single-level mount point)
+doesn't hit.
+
+## Gotchas (learned the hard way)
+
+- **Kill restic by exact name, `pkill -x restic` — never `pkill -f restic`.**
+  The backup script's own command line contains `restic-password.txt` and the
+  repo path, so an `-f` pattern matches and **SIGKILLs the script itself**.
+  SIGKILL can't be trapped, so cleanup never runs and you get a *false* leak that
+  looks like a real bug.
+- **`lvremove` needs a retry window.** Right after a reader (restic) exits and
+  the snapshot is unmounted, the device can stay transiently busy; a single
+  `lvremove` fails while a retry a moment later succeeds. The cleanup does
+  `udevadm settle` + retry — this was caught by the wrong-password scenario,
+  which is the only one where restic actually reads the snapshot before failing.
+- **Bash defers a trapped signal until the running foreground command returns.**
+  So a `SIGTERM`/`SIGINT` sent only to the script won't act until the in-progress
+  `restic` finishes. The signal scenarios therefore also kill `restic` to unblock
+  the trap promptly. In real interactive use, `Ctrl-C` reaches the whole process
+  group (including restic), so this happens naturally.
+- **`SIGKILL` (`kill -9`) to the script can't be defended against** — no trap
+  runs, so a hard kill of `rlvm`/the script can still leak. The trap covers
+  every *catchable* exit (errors, `INT`/`TERM`/`HUP`, normal exit).
+
+## Interpreting a failure
+
+A `FAIL` row prints the offending leaked temp dir(s), then the harness
+best-effort cleans up (lazy-unmount anything under `/tmp/resticlvm-*`,
+`lvremove -f` any `_snapshot_` LV, remove temp dirs) so the next scenario starts
+from a clean slate. If a run leaves anything behind, recover manually:
+
+```bash
+SNAP=/tmp/resticlvm-<ts>/<snapshot-dir>
+sudo umount -l "$SNAP"/* 2>/dev/null; sudo umount -l "$SNAP" 2>/dev/null
+sudo lvremove -f /dev/<vg>/<snapshot-name>
+sudo rm -rf /tmp/resticlvm-*
+```


### PR DESCRIPTION
## What

Preserves the failure-injection harness used to verify the #24 cleanup trap, so
it's a reusable regression check for any future change to the snapshot
create/mount/teardown path — directly relevant to the queued #46/#57 multi-repo
failure work.

Previously these scripts lived only in a throwaway scratch dir. This commits
them to the repo with a runbook.

## Contents

- **`docs/FAILURE_INJECTION_TESTING.md`** — runbook: what it checks, prereqs,
  how to run the root and nonroot paths, the scenario table, and the gotchas
  learned while building it.
- **`dev/failure-injection/`** — runnable scripts, parameterized via env vars
  with dev-VM defaults:
  - `verify_root.sh` — 5 root-path scenarios (restic fails mid-run, bind step
    fails, restic SIGKILLed, SIGTERM, SIGINT).
  - `setup_nonroot.sh` / `verify_nonroot.sh` / `teardown_nonroot.sh` — nonroot
    path on a throwaway 1G LV (3 scenarios).
  - `_common.sh` — shared assertions/helpers.

  Each scenario asserts **non-zero exit and zero leaked snapshot LVs / mounts /
  temp dirs**.

## Gotchas captured (so we don't relearn them)

- Kill restic by **exact name** (`pkill -x restic`), never `-f restic` — the
  backup script's cmdline contains `restic-password.txt`/the repo path, so `-f`
  SIGKILLs the untrappable script and fakes a leak.
- `lvremove` needs `udevadm settle` + a retry window (snapshot device stays
  briefly busy after a reader exits).
- Bash defers a trapped signal until the running foreground command returns, so
  signal scenarios also end restic to fire the trap promptly.
- `SIGKILL` to the script is undefendable (no trap runs).

## Notes

Docs + dev tooling only — no runtime code changes. Scripts are `shellcheck`
clean, and the configs they generate parse through the real
`BackupConfigFactory`. Intended to be run **only in the disposable Debian+LVM
dev VM** (see `docs/FRASER_VM_READY.md`), never against a live system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)