### PR TITLE
fix(backup): continue to remaining repositories when one fails (#46)

### DIFF
--- a/dev/failure-injection/verify_multirepo.sh
+++ b/dev/failure-injection/verify_multirepo.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Multi-repo resilience verification — issue #46. Run as root.
+#   sudo bash verify_multirepo.sh "$(command -v rlvm)"
+#
+# Proves that within one lv_root job a failing repository does NOT block the
+# others: whichever position the bad repo takes, the good repo still gets a new
+# snapshot, the job exits non-zero, #24 cleanup still holds, and the controlled
+# exit prints no "aborted" trap message.
+#
+# Env overrides (defaults suit the dev VM):
+#   VG=vg0  LV=lv_root  GOOD_REPO=/srv/backup/root-local  BAD_REPO=/srv/backup/root-bad
+#   PW=/etc/resticlvm/restic-password.txt
+set -uo pipefail
+
+RLVM="${1:-${RLVM:-}}"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/_common.sh"
+fi_require_rlvm
+
+: "${LV:=lv_root}"
+: "${GOOD_REPO:=/srv/backup/root-local}"
+: "${BAD_REPO:=/srv/backup/root-bad}"
+
+# The wrong-password file must live inside the root snapshot/chroot (not in
+# /tmp), so the bad repo fails on a genuine wrong password rather than a missing
+# file.
+WRONGPW=/etc/resticlvm/wrong-password.txt
+echo 'the-wrong-password' > "$WRONGPW"
+trap 'rm -f "$WRONGPW" 2>/dev/null || true' EXIT
+
+fi_clean_stale_tmp
+
+# Ensure the "bad" repo exists, initialized with the CORRECT password (the
+# failure is purely the wrong password referenced in the config).
+restic -r "$BAD_REPO" --password-file "$PW" cat config >/dev/null 2>&1 \
+    || restic -r "$BAD_REPO" --password-file "$PW" init >/dev/null 2>&1
+
+prune_block() { printf '[prune_policy.standard]\nkeep_last = 10\nkeep_daily = 7\nkeep_weekly = 4\nkeep_monthly = 6\nkeep_yearly = 1\n'; }
+vol_head()    { printf '\n[volume.root]\nvolume_type = "lv_root"\nvg_name = "%s"\nlv_name = "%s"\nsnapshot_size = "2G"\nbackup_source_path = "/"\nexclude_paths = ["/dev","/proc","/sys","/tmp","/srv/backup"]\n' "$VG" "$LV"; }
+repo_block()  { printf '\n[[volume.root.repositories]]\nrepo_path = "%s"\npassword_file = "%s"\nprune_policy = "standard"\n' "$1" "$2"; }
+
+# Count snapshots robustly: restic --json prints the array on one line, so count
+# occurrences (grep -o), not matching lines (grep -c).
+snap_count() { restic -r "$1" --password-file "$PW" snapshots --json 2>/dev/null | grep -o '"short_id"' | wc -l | tr -d ' '; }
+
+run_case() { # $1 = case name, $2 = config path
+    local name="$1" cfg="$2" before after rc log good_delta snaps mounts dirs
+    log="$FI_WORKDIR/${name}.log"
+    before=$(snap_count "$GOOD_REPO")
+    "$RLVM" backup --config "$cfg" >"$log" 2>&1; rc=$?
+    after=$(snap_count "$GOOD_REPO")
+    good_delta=$((after - before))
+    snaps=$(lvs --noheadings -o lv_name "$VG" 2>/dev/null | grep -c '_snapshot_')
+    mounts=$(mount 2>/dev/null | grep -c '/tmp/resticlvm-')
+    dirs=$(find /tmp -maxdepth 1 -name 'resticlvm-*' -type d 2>/dev/null | wc -l)
+
+    echo "  ── $name ──"
+    echo "     exit code             : $rc  ($([ "$rc" -ne 0 ] && echo 'non-zero OK' || echo 'ZERO — unexpected'))"
+    echo "     good repo new snapshot: +$good_delta  ($([ "$good_delta" -eq 1 ] && echo OK || echo 'WRONG — good repo not backed up!'))"
+    echo "     summary line          : $(grep -oE '[0-9]+/[0-9]+ repository\(ies\) succeeded, [0-9]+ failed' "$log" | tail -1)"
+    echo "     leaks (snap/mnt/dir)  : $snaps / $mounts / $dirs  ($([ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ] && echo OK || echo LEAK))"
+    echo "     no 'aborted' trap msg : $(grep -q 'Backup aborted' "$log" && echo 'NO — unexpected' || echo OK)"
+
+    if [ "$rc" -ne 0 ] && [ "$good_delta" -eq 1 ] && [ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ] \
+       && ! grep -q 'Backup aborted' "$log"; then
+        echo "     RESULT: PASS"; fi_pass=$((fi_pass + 1))
+    else
+        echo "     RESULT: FAIL   (full log: $log)"; fi_fail=$((fi_fail + 1))
+        mount | awk '/\/tmp\/resticlvm-/ {print $3}' | sort -r | xargs -r -n1 umount -l 2>/dev/null
+        lvs --noheadings -o lv_name "$VG" 2>/dev/null | grep '_snapshot_' | xargs -r -n1 -I{} lvremove -f "/dev/$VG/{}" 2>/dev/null
+        rm -rf /tmp/resticlvm-* 2>/dev/null
+    fi
+}
+
+# Bad repo FIRST — the pre-#46 failure mode (early failure blocked the good repo).
+{ prune_block; vol_head; repo_block "$BAD_REPO" "$WRONGPW"; repo_block "$GOOD_REPO" "$PW"; } > "$FI_WORKDIR/bad_first.toml"
+run_case "bad-first_good-second" "$FI_WORKDIR/bad_first.toml"
+
+# Bad repo SECOND — good backs up, then the bad one fails.
+{ prune_block; vol_head; repo_block "$GOOD_REPO" "$PW"; repo_block "$BAD_REPO" "$WRONGPW"; } > "$FI_WORKDIR/good_first.toml"
+run_case "good-first_bad-second" "$FI_WORKDIR/good_first.toml"
+
+fi_summary "Multi-repo resilience (#46)"

--- a/docs/FAILURE_INJECTION_TESTING.md
+++ b/docs/FAILURE_INJECTION_TESTING.md
@@ -51,6 +51,18 @@ sudo bash dev/failure-injection/verify_nonroot.sh "$(command -v rlvm)"
 sudo bash dev/failure-injection/teardown_nonroot.sh          # when done
 ```
 
+Multi-repo resilience (issue #46 — a failing repo must not block the others):
+
+```bash
+sudo bash dev/failure-injection/verify_multirepo.sh "$(command -v rlvm)"
+```
+
+Runs a two-repo `lv_root` job with the bad repo first, then bad repo second, and
+asserts that in both orderings the good repo still gets a new snapshot, the job
+exits non-zero, no snapshot/mount/temp dir leaks, and no "aborted" trap message
+is printed (the controlled partial-failure exit path). It creates/uses a `bad`
+repo referenced with a wrong password.
+
 Each verify script prints a per-scenario table and a final `N passed, M failed`
 summary (exit 0 iff all passed), and prints a control-run command using a
 generated good config so you can confirm the happy path still succeeds cleanly.

--- a/src/resticlvm/scripts/backup_lv_nonroot.sh
+++ b/src/resticlvm/scripts/backup_lv_nonroot.sh
@@ -113,13 +113,14 @@ populate_restic_tags_for_lv_nonroot RESTIC_TAGS "$EXCLUDE_PATHS" "$SNAPSHOT_MOUN
 # ─── Loop Over Repositories ───────────────────────────────────────
 echo "🚀 Backing up to ${#RESTIC_REPOS[@]} repository(ies)..."
 
+FAILED_REPOS=()
 for i in "${!RESTIC_REPOS[@]}"; do
     RESTIC_REPO="${RESTIC_REPOS[$i]}"
     RESTIC_PASSWORD_FILE="${RESTIC_PASSWORD_FILES[$i]}"
-    
+
     echo ""
     echo "▶️  Repository $((i+1))/${#RESTIC_REPOS[@]}: $RESTIC_REPO"
-    
+
     # Build Restic command for this repo
     RESTIC_CMD="restic -r $RESTIC_REPO"
     RESTIC_CMD+=" --password-file=$RESTIC_PASSWORD_FILE"
@@ -127,13 +128,22 @@ for i in "${!RESTIC_REPOS[@]}"; do
     RESTIC_CMD+=" ${EXCLUDE_ARGS[*]}"
     RESTIC_CMD+=" ${RESTIC_TAGS[*]}"
     RESTIC_CMD+=" --verbose"
-    
-    # Execute backup for this repo
-    run_or_echo "$DRY_RUN" "$RESTIC_CMD"
+
+    # Execute backup for this repo. A failure must not prevent the remaining
+    # repositories from being attempted (issue #46).
+    if run_or_echo "$DRY_RUN" "$RESTIC_CMD"; then
+        echo "✅ Repository backup succeeded: $RESTIC_REPO"
+    else
+        echo "❌ Repository backup failed: $RESTIC_REPO"
+        FAILED_REPOS+=("$RESTIC_REPO")
+    fi
 done
 
 # ─── Cleanup ──────────────────────────────────────────────────────
 clean_up_snapshot "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$VG_NAME" "$SNAP_NAME"
+# Read by the EXIT trap (_snapshot_cleanup_trap) to distinguish an orderly exit
+# from an abort; see lib/lv_snapshots.sh.
+# shellcheck disable=SC2034
+RLVM_CLEANUP_DONE=1
 
-echo ""
-echo "✅ Backup completed for ${#RESTIC_REPOS[@]} repository(ies) (or would have, in dry-run mode)."
+report_repo_outcomes "${#RESTIC_REPOS[@]}" ${FAILED_REPOS[@]+"${FAILED_REPOS[@]}"} || exit 1

--- a/src/resticlvm/scripts/backup_lv_root.sh
+++ b/src/resticlvm/scripts/backup_lv_root.sh
@@ -109,17 +109,23 @@ populate_restic_tags RESTIC_TAGS "$EXCLUDE_PATHS"
 # ─── Loop Over Repositories ───────────────────────────────────────
 echo "🚀 Backing up to ${#RESTIC_REPOS[@]} repository(ies)..."
 
+FAILED_REPOS=()
 for i in "${!RESTIC_REPOS[@]}"; do
     RESTIC_REPO="${RESTIC_REPOS[$i]}"
     RESTIC_PASSWORD_FILE="${RESTIC_PASSWORD_FILES[$i]}"
-    
+
     echo ""
     echo "▶️  Repository $((i+1))/${#RESTIC_REPOS[@]}: $RESTIC_REPO"
-    
-    # Bind this repo to chroot (skip for remote repos)
+
+    # Bind this repo to chroot (skip for remote repos). If the bind fails,
+    # record it and move on to the next repo rather than aborting (issue #46).
     CHROOT_REPO_FULL="$CHROOT_REPO_PATH/$(basename "$RESTIC_REPO")"
-    bind_repo_to_mounted_snapshot "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$RESTIC_REPO" "$CHROOT_REPO_FULL"
-    
+    if ! bind_repo_to_mounted_snapshot "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$RESTIC_REPO" "$CHROOT_REPO_FULL"; then
+        echo "❌ Failed to prepare repository: $RESTIC_REPO"
+        FAILED_REPOS+=("$RESTIC_REPO")
+        continue
+    fi
+
     # Determine which repo path to use in restic command
     if is_remote_repo "$RESTIC_REPO"; then
         # Remote repo - use the URL directly
@@ -128,7 +134,7 @@ for i in "${!RESTIC_REPOS[@]}"; do
         # Local repo - use the chroot-bound path
         EFFECTIVE_REPO="$CHROOT_REPO_FULL"
     fi
-    
+
     # Build Restic command for this repo
     RESTIC_CMD="export RESTIC_PASSWORD_FILE=$RESTIC_PASSWORD_FILE && restic"
     RESTIC_CMD+=" ${EXCLUDE_ARGS[*]}"
@@ -136,18 +142,30 @@ for i in "${!RESTIC_REPOS[@]}"; do
     RESTIC_CMD+=" -r $EFFECTIVE_REPO"
     RESTIC_CMD+=" backup $BACKUP_SOURCE_PATH"
     RESTIC_CMD+=" --verbose"
-    
-    # Execute backup for this repo
-    run_in_chroot_or_echo "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$RESTIC_CMD"
-    
-    # Unbind just this repo from chroot (keep /dev, /proc, /sys for next repo)
-    unmount_repo_binding "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$CHROOT_REPO_FULL" "$RESTIC_REPO"
+
+    # Execute backup for this repo. A failure must not prevent the remaining
+    # repositories from being attempted (issue #46).
+    if run_in_chroot_or_echo "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$RESTIC_CMD"; then
+        echo "✅ Repository backup succeeded: $RESTIC_REPO"
+    else
+        echo "❌ Repository backup failed: $RESTIC_REPO"
+        FAILED_REPOS+=("$RESTIC_REPO")
+    fi
+
+    # Always unbind this repo before the next iteration, even on failure. A
+    # failed unbind is non-fatal — teardown will sweep any leftover bind.
+    if ! unmount_repo_binding "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$CHROOT_REPO_FULL" "$RESTIC_REPO"; then
+        echo "⚠️  Warning: could not unbind repository (will be cleaned up at teardown): $RESTIC_REPO"
+    fi
 done
 
 # ─── Cleanup ──────────────────────────────────────────────────────
 # Unmount chroot essentials once after all repos are done
 unmount_chroot_essentials "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT"
 clean_up_snapshot "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$VG_NAME" "$SNAP_NAME"
+# Read by the EXIT trap (_snapshot_cleanup_trap) to distinguish an orderly exit
+# from an abort; see lib/lv_snapshots.sh.
+# shellcheck disable=SC2034
+RLVM_CLEANUP_DONE=1
 
-echo ""
-echo "✅ Backup completed for ${#RESTIC_REPOS[@]} repository(ies) (or would have, in dry-run mode)."
+report_repo_outcomes "${#RESTIC_REPOS[@]}" ${FAILED_REPOS[@]+"${FAILED_REPOS[@]}"} || exit 1

--- a/src/resticlvm/scripts/backup_path.sh
+++ b/src/resticlvm/scripts/backup_path.sh
@@ -76,24 +76,30 @@ populate_restic_tags RESTIC_TAGS "$EXCLUDE_PATHS"
 # ─── Loop Over Repositories ───────────────────────────────────────
 echo "🚀 Backing up to ${#RESTIC_REPOS[@]} repository(ies)..."
 
+FAILED_REPOS=()
 for i in "${!RESTIC_REPOS[@]}"; do
     RESTIC_REPO="${RESTIC_REPOS[$i]}"
     RESTIC_PASSWORD_FILE="${RESTIC_PASSWORD_FILES[$i]}"
-    
+
     echo ""
     echo "▶️  Repository $((i+1))/${#RESTIC_REPOS[@]}: $RESTIC_REPO"
-    
+
     # Build Restic command for this repo
     RESTIC_CMD="restic -r $RESTIC_REPO --password-file=$RESTIC_PASSWORD_FILE"
     RESTIC_CMD+=" ${EXCLUDE_ARGS[*]}"
     RESTIC_CMD+=" ${RESTIC_TAGS[*]}"
     RESTIC_CMD+=" backup $BACKUP_SOURCE_PATH"
     RESTIC_CMD+=" --verbose"
-    
-    # Execute backup for this repo
-    run_or_echo "$DRY_RUN" "$RESTIC_CMD"
+
+    # Execute backup for this repo. A failure must not prevent the remaining
+    # repositories from being attempted (issue #46).
+    if run_or_echo "$DRY_RUN" "$RESTIC_CMD"; then
+        echo "✅ Repository backup succeeded: $RESTIC_REPO"
+    else
+        echo "❌ Repository backup failed: $RESTIC_REPO"
+        FAILED_REPOS+=("$RESTIC_REPO")
+    fi
 done
 
 # ─── Done ─────────────────────────────────────────────────────────
-echo ""
-echo "✅ Backup completed for ${#RESTIC_REPOS[@]} repository(ies) (or would have, in dry-run mode)."
+report_repo_outcomes "${#RESTIC_REPOS[@]}" ${FAILED_REPOS[@]+"${FAILED_REPOS[@]}"} || exit 1

--- a/src/resticlvm/scripts/lib/lv_snapshots.sh
+++ b/src/resticlvm/scripts/lib/lv_snapshots.sh
@@ -147,7 +147,10 @@ _snapshot_cleanup_trap() {
     local rc=$?
     trap - EXIT INT TERM HUP
     if [ "${DRY_RUN:-false}" != true ]; then
-        if [ "$rc" -ne 0 ]; then
+        # Only announce a "releasing…" cleanup for an actual abort. A controlled
+        # non-zero exit after orderly teardown (e.g. a partial multi-repo
+        # failure, issue #46) sets RLVM_CLEANUP_DONE=1 and stays quiet.
+        if [ "$rc" -ne 0 ] && [ "${RLVM_CLEANUP_DONE:-0}" != 1 ]; then
             echo "" >&2
             echo "⚠️  Backup aborted (exit $rc) — releasing LVM snapshot and mounts…" >&2
         fi

--- a/src/resticlvm/scripts/lib/message_display.sh
+++ b/src/resticlvm/scripts/lib/message_display.sh
@@ -60,3 +60,28 @@ display_dry_run_message() {
         echo -e "\n🟡 The following describes what *would* happen if this were a real backup run.\n"
     fi
 }
+
+# Report per-repository backup outcomes for a single job (issue #46). Every
+# repository is attempted regardless of individual failures; this prints the
+# summary and returns 0 only if all succeeded, 1 if any failed — so the caller
+# can exit non-zero (marking the job failed) while still having backed up to the
+# working destinations.
+#   $1        total repository count
+#   $2..$N    repo_path of each failed repository (may be none)
+report_repo_outcomes() {
+    local total="$1"
+    shift
+    local failed=("$@")
+    local nfail=${#failed[@]}
+    local nok=$((total - nfail))
+
+    echo ""
+    if [ "$nfail" -eq 0 ]; then
+        echo "✅ Backup completed for all ${total} repository(ies) (or would have, in dry-run mode)."
+        return 0
+    fi
+
+    echo "❌ Backup finished with failures: ${nok}/${total} repository(ies) succeeded, ${nfail} failed:"
+    printf '   ✗ %s\n' "${failed[@]}"
+    return 1
+}


### PR DESCRIPTION
## What

Within a single job the backup scripts process all repositories in one
invocation, and under `set -euo pipefail` the **first** repo failure (a
misconfigured password, an unreachable remote, …) aborted the script — so the
remaining, correctly-configured destinations were never attempted.

Now every repository is attempted regardless of individual failures; the job
reports which succeeded and which failed and exits non-zero if any failed (so it
is still marked failed). Applies to all three loops: `backup_path.sh`,
`backup_lv_root.sh`, `backup_lv_nonroot.sh`.

## How

- Each `restic` backup runs in an `if` so a failure records the repo in
  `FAILED_REPOS` and continues instead of aborting.
- `lv_root`: a failed per-repo *bind* also records-and-continues, and the
  per-repo unbind is non-fatal (teardown sweeps any leftover bind).
- New shared `report_repo_outcomes()` (`lib/message_display.sh`) prints the
  per-job summary and returns non-zero iff any repo failed; callers `|| exit 1`.
- The snapshot scripts set `RLVM_CLEANUP_DONE=1` after orderly teardown so the
  #24 EXIT trap treats a partial-failure exit as a *controlled* exit (idempotent
  sweep, no "aborted — releasing" message) rather than an abort.

Cross-job isolation and `copy_to` behavior are unchanged: copies still run only
when the backup script fully succeeds.

## Verification

New committed harness `dev/failure-injection/verify_multirepo.sh` (documented in
`docs/FAILURE_INJECTION_TESTING.md`), run in the Debian+LVM VM:

| Ordering | good repo new snapshot | job exit | leaks | abort msg |
| --- | --- | --- | --- | --- |
| bad repo **first**, good second | **+1** | non-zero | none | none |
| good first, bad **second** | **+1** | non-zero | none | none |

i.e. the good repo backs up regardless of the bad repo's position (the
pre-#46 failure mode was `+0` for bad-first), the job is still marked failed, and
#24 cleanup still holds. `shellcheck` clean; 103 unit tests pass.

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)