### PR TITLE
fix(output): restore terminal foreground process group after subprocesses (#57)

### DIFF
--- a/src/resticlvm/orchestration/data_classes.py
+++ b/src/resticlvm/orchestration/data_classes.py
@@ -16,6 +16,7 @@ from resticlvm.orchestration.credentials import (
     load_b2_credentials,
     repo_uses_b2,
 )
+from resticlvm.orchestration.terminal import preserved_terminal
 
 
 @dataclass
@@ -180,13 +181,18 @@ class BackupJob:
                 )
 
         try:
-            subprocess.run(
-                args=self.cmd,
-                check=True,
-                stdout=sys.stdout,
-                stderr=sys.stderr,
-                env=env,
-            )
+            # ssh (spawned by restic for SFTP) can leave the terminal's
+            # foreground process group pointing at its dead group on failure,
+            # which makes later restic runs suppress their output; restore it
+            # afterward so subsequent jobs' output isn't lost (issue #57).
+            with preserved_terminal():
+                subprocess.run(
+                    args=self.cmd,
+                    check=True,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    env=env,
+                )
             print(f"✅ Backup [{self.category}.{self.name}] completed.\n")
 
             # After successful backup, copy to remote destinations
@@ -241,13 +247,15 @@ class BackupJob:
                     cmd.append("-n")
 
                 try:
-                    subprocess.run(
-                        args=cmd,
-                        check=True,
-                        stdout=sys.stdout,
-                        stderr=sys.stderr,
-                        env=env,
-                    )
+                    # Copy targets can be remote (ssh); guard the terminal (#57).
+                    with preserved_terminal():
+                        subprocess.run(
+                            args=cmd,
+                            check=True,
+                            stdout=sys.stdout,
+                            stderr=sys.stderr,
+                            env=env,
+                        )
                     print(f"✅ Copy to {copy_dest.repo_path} completed.\n")
                 except subprocess.CalledProcessError as e:
                     print(f"❌ Copy to {copy_dest.repo_path} failed: {e}\n")

--- a/src/resticlvm/orchestration/restic_repo.py
+++ b/src/resticlvm/orchestration/restic_repo.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from resticlvm import scripts
+from resticlvm.orchestration.terminal import preserved_terminal
 
 
 @dataclass
@@ -81,9 +82,12 @@ class ResticRepo:
         env['SSH_AUTH_SOCK'] = '/root/.ssh/ssh-agent.sock'
 
         try:
-            subprocess.run(
-                cmd, check=True, stdout=sys.stdout, stderr=sys.stderr, env=env
-            )
+            # Pruning a remote repo runs ssh; guard the terminal (issue #57).
+            with preserved_terminal():
+                subprocess.run(
+                    cmd, check=True, stdout=sys.stdout, stderr=sys.stderr,
+                    env=env,
+                )
             print(f"✅ Prune completed for {self.repo_path}\n")
         except subprocess.CalledProcessError as e:
             print(f"❌ Prune failed for {self.repo_path}: {e}")

--- a/src/resticlvm/orchestration/terminal.py
+++ b/src/resticlvm/orchestration/terminal.py
@@ -1,0 +1,84 @@
+"""Terminal-state guarding around subprocesses that may spawn ssh.
+
+restic's SFTP backend runs ``ssh``, which takes over the controlling terminal's
+**foreground process group** to read a host-key/password prompt and, on failure,
+does not restore it — leaving the terminal's foreground group pointing at ssh's
+(now dead) process group. restic, like most tools with terminal progress output,
+suppresses *all* of its terminal output when it detects it is not the foreground
+process. So after one remote failure every subsequent ``restic`` prints nothing,
+even though the backups still succeed (issue #57). (Plain ``print``/``echo``
+still show because they don't do that foreground check.)
+
+:func:`preserved_terminal` snapshots the terminal's foreground process group
+before a subprocess and restores it afterward, the way a job-control shell does.
+"""
+
+import os
+import signal
+import sys
+from contextlib import contextmanager
+
+
+def _tty_fds():
+    """Yield the distinct TTY file descriptors among stdin/stdout/stderr."""
+    seen = set()
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            fd = stream.fileno()
+        except (AttributeError, OSError, ValueError):
+            continue
+        if fd in seen:
+            continue
+        seen.add(fd)
+        try:
+            if os.isatty(fd):
+                yield fd
+        except OSError:
+            continue
+
+
+def _set_foreground_pgrp(fd, pgrp):
+    """Set fd's terminal foreground process group to ``pgrp``.
+
+    Calling this from a process that is not currently in the foreground group
+    would itself raise ``SIGTTOU`` (whose default action stops us), so ignore
+    ``SIGTTOU`` for the duration — the standard job-control idiom.
+    """
+    try:
+        old = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+    except (ValueError, OSError):
+        old = None  # not the main thread; best-effort without masking SIGTTOU
+    try:
+        os.tcsetpgrp(fd, pgrp)
+    finally:
+        if old is not None:
+            try:
+                signal.signal(signal.SIGTTOU, old)
+            except (ValueError, OSError):
+                pass
+
+
+@contextmanager
+def preserved_terminal():
+    """Restore the terminal's foreground process group after the wrapped block.
+
+    Wrap any ``subprocess.run`` that may spawn ssh (backup, copy, prune) so a
+    remote failure can't leave the terminal's foreground group pointing at a dead
+    process and silence later output (issue #57). No-op when not attached to a
+    TTY (cron, pipes).
+    """
+    saved = {}
+    for fd in _tty_fds():
+        try:
+            saved[fd] = os.tcgetpgrp(fd)
+        except OSError:
+            continue
+    try:
+        yield
+    finally:
+        for fd, pgrp in saved.items():
+            try:
+                if os.tcgetpgrp(fd) != pgrp:
+                    _set_foreground_pgrp(fd, pgrp)
+            except OSError:
+                pass

--- a/test/test_terminal.py
+++ b/test/test_terminal.py
@@ -1,0 +1,75 @@
+"""Tests for the terminal foreground-process-group guard (issue #57)."""
+
+import os
+
+import pytest
+
+from resticlvm.orchestration import terminal
+
+
+def test_restores_foreground_pgrp_when_ssh_changed_it(monkeypatch):
+    """If a subprocess leaves the terminal's foreground pgrp changed, it's
+    restored to what it was before the block."""
+    fg = {"pgrp": 100}
+    set_calls = []
+    monkeypatch.setattr(terminal, "_tty_fds", lambda: iter([7]))
+    monkeypatch.setattr(os, "tcgetpgrp", lambda fd: fg["pgrp"])
+
+    def fake_set(fd, pgrp):
+        set_calls.append((fd, pgrp))
+        fg["pgrp"] = pgrp
+
+    monkeypatch.setattr(os, "tcsetpgrp", fake_set)
+
+    with terminal.preserved_terminal():
+        fg["pgrp"] = 999  # simulate ssh grabbing the terminal
+
+    assert set_calls == [(7, 100)]
+
+
+def test_no_restore_when_pgrp_unchanged(monkeypatch):
+    """No tcsetpgrp when nothing disturbed the foreground group."""
+    set_calls = []
+    monkeypatch.setattr(terminal, "_tty_fds", lambda: iter([7]))
+    monkeypatch.setattr(os, "tcgetpgrp", lambda fd: 100)
+    monkeypatch.setattr(os, "tcsetpgrp",
+                        lambda fd, pgrp: set_calls.append((fd, pgrp)))
+
+    with terminal.preserved_terminal():
+        pass
+
+    assert set_calls == []
+
+
+def test_restores_pgrp_even_on_exception(monkeypatch):
+    """The foreground group is restored even if the wrapped block raises."""
+    fg = {"pgrp": 100}
+    set_calls = []
+    monkeypatch.setattr(terminal, "_tty_fds", lambda: iter([7]))
+    monkeypatch.setattr(os, "tcgetpgrp", lambda fd: fg["pgrp"])
+
+    def fake_set(fd, pgrp):
+        set_calls.append((fd, pgrp))
+        fg["pgrp"] = pgrp
+
+    monkeypatch.setattr(os, "tcsetpgrp", fake_set)
+
+    with pytest.raises(RuntimeError):
+        with terminal.preserved_terminal():
+            fg["pgrp"] = 999
+            raise RuntimeError("boom")
+
+    assert set_calls == [(7, 100)]
+
+
+def test_noop_when_not_a_tty(monkeypatch):
+    """No tcsetpgrp attempted when there's no TTY (cron, pipes)."""
+    set_calls = []
+    monkeypatch.setattr(terminal, "_tty_fds", lambda: iter([]))
+    monkeypatch.setattr(os, "tcsetpgrp",
+                        lambda fd, pgrp: set_calls.append((fd, pgrp)))
+
+    with terminal.preserved_terminal():
+        pass
+
+    assert set_calls == []


### PR DESCRIPTION
## What

After a remote (SFTP) repository failed, restic's `--verbose` output disappeared
for local repos in all subsequent jobs, even though the backups succeeded and the
job headers still printed.

## Root cause (confirmed by instrumenting terminal state)

restic's SFTP backend runs `ssh`, which **takes over the controlling terminal's
foreground process group** to read its host-key/password prompt and, on failure,
doesn't restore it — leaving the terminal's foreground group pointing at ssh's
now-dead process group. restic (like most tools with terminal progress output)
**suppresses all of its terminal output when it detects it is not the foreground
process**, so every later restic prints nothing. It persists across jobs because
each job subprocess inherits the same terminal; the shell recovers afterward
because readline re-asserts the foreground group before its prompt.

Diagnostic on the failing case showed `tcgetpgrp(1)` change from the rlvm group
to ssh's group and stay there, while terminal blocking mode and every termios
flag were **unchanged** — ruling out the blocking/termios theories and pinning it
on the foreground pgroup.

## Fix

New `orchestration/terminal.py` with a `preserved_terminal()` context manager
that snapshots the terminal's foreground process group (`os.tcgetpgrp`) before
the block and restores it afterward (`os.tcsetpgrp`, with `SIGTTOU` ignored — the
job-control idiom) if a subprocess changed it. Wrap the three `subprocess.run`
sites that can spawn ssh: the backup job and copy operations
(`data_classes.py`) and prune (`restic_repo.py`). No-op when not attached to a
TTY, so cron/pipe runs are unaffected.

## Verification

- In a VM: reproduced (failing SFTP job → next job's local restic output was
  gone), then confirmed the fix restores the next job's full restic output.
- Unit tests over the manager: restores a changed pgroup (incl. when the block
  raises), no-ops when the pgroup is unchanged, no-ops without a TTY. 107 tests
  pass.

## Scope / follow-up

This fixes the reported **cross-job** case. A narrower **within-job** case — a
remote repo failing *before* a local repo in the *same* job — is not covered,
because a job is a single subprocess so the pgroup is only restored between jobs.
That's a residual of the multi-repo-per-job behavior from #46 and only occurs
with misconfigured remote auth ordered before a local repo in one volume; it
needs a bash-level reset in the loop. Tracked as a follow-up issue.

Fixes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)