### PR TITLE
fix(output): restore terminal foreground pgroup between repos in a job (#72)

### DIFF
--- a/src/resticlvm/scripts/backup_lv_nonroot.sh
+++ b/src/resticlvm/scripts/backup_lv_nonroot.sh
@@ -137,6 +137,10 @@ for i in "${!RESTIC_REPOS[@]}"; do
         echo "❌ Repository backup failed: $RESTIC_REPO"
         FAILED_REPOS+=("$RESTIC_REPO")
     fi
+
+    # A remote repo's ssh can grab the terminal and not give it back, which would
+    # suppress the next repo's restic output; restore it here (issue #72).
+    restore_terminal_foreground
 done
 
 # ─── Cleanup ──────────────────────────────────────────────────────

--- a/src/resticlvm/scripts/backup_lv_root.sh
+++ b/src/resticlvm/scripts/backup_lv_root.sh
@@ -157,6 +157,10 @@ for i in "${!RESTIC_REPOS[@]}"; do
     if ! unmount_repo_binding "$DRY_RUN" "$SNAPSHOT_MOUNT_POINT" "$CHROOT_REPO_FULL" "$RESTIC_REPO"; then
         echo "⚠️  Warning: could not unbind repository (will be cleaned up at teardown): $RESTIC_REPO"
     fi
+
+    # A remote repo's ssh can grab the terminal and not give it back, which would
+    # suppress the next repo's restic output; restore it here (issue #72).
+    restore_terminal_foreground
 done
 
 # ─── Cleanup ──────────────────────────────────────────────────────

--- a/src/resticlvm/scripts/backup_path.sh
+++ b/src/resticlvm/scripts/backup_path.sh
@@ -99,6 +99,10 @@ for i in "${!RESTIC_REPOS[@]}"; do
         echo "❌ Repository backup failed: $RESTIC_REPO"
         FAILED_REPOS+=("$RESTIC_REPO")
     fi
+
+    # A remote repo's ssh can grab the terminal and not give it back, which would
+    # suppress the next repo's restic output; restore it here (issue #72).
+    restore_terminal_foreground
 done
 
 # ─── Done ─────────────────────────────────────────────────────────

--- a/src/resticlvm/scripts/lib/command_runners.sh
+++ b/src/resticlvm/scripts/lib/command_runners.sh
@@ -40,3 +40,26 @@ run_in_chroot_or_echo() {
         fi
     fi
 }
+
+# Restore the controlling terminal's foreground process group to this script's
+# own group. restic's ssh (for a remote repo) can take over the terminal's
+# foreground group to show a prompt and, on failure, not restore it — which
+# makes the NEXT restic in the loop believe it is backgrounded and suppress its
+# output (issue #72, the within-job residual of #57). Call it after each repo.
+# No-op without a controlling terminal on stdout or without python3, so cron and
+# piped runs are unaffected. The Python child shares this script's process
+# group, so os.getpgrp() is the group we want to be foreground.
+restore_terminal_foreground() {
+    [ -t 1 ] || return 0
+    command -v python3 >/dev/null 2>&1 || return 0
+    python3 - <<'PY' 2>/dev/null || true
+import os
+import signal
+try:
+    if os.isatty(1) and os.tcgetpgrp(1) != os.getpgrp():
+        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        os.tcsetpgrp(1, os.getpgrp())
+except Exception:
+    pass
+PY
+}


### PR DESCRIPTION
## What

The within-job residual of #57. When a job backs up to multiple repositories and
a remote (SFTP) repo fails **before** a local repo in the **same** job, the local
repo's restic `--verbose` output was suppressed (the backup still succeeded).

#57 restores the terminal's foreground process group **between jobs**, but a job
runs in a single subprocess, so nothing reset it **between repos** inside the
loop. ssh's grab of the terminal's foreground group therefore persisted to the
next repo, and restic self-silences when it detects it isn't the foreground
process.

## How

- New `restore_terminal_foreground()` in `lib/command_runners.sh`: resets the
  controlling terminal's foreground process group to the script's own group via a
  small `python3` snippet (`tcsetpgrp` with `SIGTTOU` ignored — the job-control
  idiom). No-op when stdout isn't a TTY or `python3` is absent, so cron/piped
  runs are unaffected.
- Called after each repository in all three loops: `backup_path.sh`,
  `backup_lv_root.sh`, `backup_lv_nonroot.sh`.

This is bash-only and independent of the #57 Python fix; the two compose for full
cross-job and within-job coverage.

## Verification

In a VM, a single job with repos ordered `[failing-sftp, local]`:

- **before:** repo 2 (local) printed only its header + success line — no restic
  detail.
- **after:** repo 2 shows the full restic output (`start scan on [/etc]`,
  `Files: …`, `snapshot … saved`).

`shellcheck` clean; existing tests pass.

## Note

Adds a `python3` invocation to the bash layer (guarded, no-op without a TTY or
python3). rlvm is a Python tool, so python3 is present whenever it drives these
scripts; standalone script runs degrade gracefully to the prior behavior.

Fixes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)