### PR TITLE
docs(CLAUDE): mark #24/#46/#57 shipped; point next work at #72

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,17 +34,29 @@ layer (`src/resticlvm/orchestration`) drives focused Bash scripts
 
 ## Status & next work
 
-- Pre-1.0. Run **attended**: a mid-run failure can leak the LVM snapshot and its
-  mounts (cleanup-on-failure is not yet automatic — this is issue #24, below).
-- **Next major task: Critical #2 / issue #24** (the LVM cleanup trap). The most common
-  leak is now root-caused: the `/dev` bind unmount intermittently fails `EBUSY` from
-  shared mount propagation (observed on a real full-system run). Two-part fix — a quick
-  `--make-private` hardening in `scripts/lib/mounts.sh`, plus the actual cleanup trap.
-  - **Plan of attack: `docs/ISSUE_24_CLEANUP_FIX_PLAN.md`** (also references
-    `docs/PRODUCTION_READINESS_REVIEW.md` Critical #2 and the 4 design questions in the
-    issue).
-  - VM with LVM is deployed on fraser (`debian13-vm`) — ready for failure-injection
-    testing. Rebuild/reconnect: see `docs/FRASER_VM_READY.md`.
-- **Queued bug fixes:** #46 (continue backing up to remaining repos when one fails)
-  and #57 (verbose output suppressed after remote repo failure). Both are patches.
+- Pre-1.0. The main correctness gaps from the production-readiness review have now
+  shipped:
+  - **Cleanup-on-failure (issue #24) — done.** A mid-run failure (restic error,
+    CoW overflow, failed mount, `Ctrl-C`/`SIGTERM`) now unwinds the LVM snapshot
+    and its mounts automatically via an idempotent `trap` (Part B, PR #68), and
+    the chroot binds are detached from shared mount propagation with
+    `--make-private` to avoid the `/dev` `EBUSY` leak (Part A, PR #65). Design:
+    `docs/ISSUE_24_CLEANUP_FIX_PLAN.md`. (The old "run attended or it leaks"
+    caveat no longer applies for catchable failures; a hard `kill -9` still can't
+    be trapped.)
+  - **#46 — done (PR #70).** A failing repository no longer aborts the job: every
+    repo is attempted, and the job is marked failed if any failed.
+  - **#57 — done (PR #71).** restic's output is no longer suppressed for later
+    jobs after a remote (ssh) failure — the terminal's foreground process group is
+    restored after each subprocess.
+- **Failure-injection harness:** `dev/failure-injection/` (runbook:
+  `docs/FAILURE_INJECTION_TESTING.md`) is the regression tool for snapshot
+  teardown and multi-repo resilience. Run it in the `debian13-vm` VM — see
+  `docs/FRASER_VM_READY.md`.
+- **Next / open:**
+  - **Within-job residual of #57** (follow-up issue): a remote repo failing
+    *before* a local repo in the *same* job still suppresses the local repo's
+    output, because a job is one subprocess so the foreground-pgroup restore only
+    runs between jobs. Fix is a bash-level pgroup reset in the repo loop.
+  - Remaining items in `docs/PRODUCTION_READINESS_REVIEW.md`.
 - Issue #55 (warn on mismatched repo names across a volume's locations) shipped in 0.7.0.


### PR DESCRIPTION
Refresh the "Status & next work" section of `CLAUDE.md` now that the three
critical items are merged.

## Changes

- **#24 (cleanup-on-failure) — done.** Note it shipped as PR #65 (Part A,
  `--make-private`) and PR #68 (Part B, the idempotent cleanup trap). Drop the
  stale "run **attended** or it leaks" caveat — a mid-run failure now unwinds the
  snapshot and its mounts automatically for any catchable exit (a hard `kill -9`
  still can't be trapped).
- **#46 — done (PR #70)** and **#57 — done (PR #71)** recorded with a one-line
  summary each.
- Reference the new **`dev/failure-injection/`** harness (runbook:
  `docs/FAILURE_INJECTION_TESTING.md`) as the regression tool.
- Record the remaining **within-job residual of #57 (issue #72)** as the next
  open item, plus the remaining `docs/PRODUCTION_READINESS_REVIEW.md` items.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)