### PR TITLE
fix(cleanup): don't leak temp-dir parents when the leaf was already removed

### DIFF
--- a/src/resticlvm/scripts/lib/lv_snapshots.sh
+++ b/src/resticlvm/scripts/lib/lv_snapshots.sh
@@ -131,7 +131,13 @@ cleanup_snapshot_resources() {
     if [ -n "$snapshot_mount_point" ] && [ -n "$mount_base" ]; then
         local dir="$snapshot_mount_point"
         while [ -n "$dir" ] && [ "$dir" != "$mount_base" ] && [ "$dir" != "/" ]; do
-            rmdir "$dir" 2>/dev/null || break
+            # Stop only if the dir still exists AND is non-empty. If it is already
+            # gone (e.g. the happy-path clean_up_snapshot already removed the leaf
+            # mount point), keep climbing to remove the now-empty parents + base —
+            # otherwise a nested nonroot mount point (…/mnt/<x>) leaks its parents.
+            if [ -d "$dir" ] && ! rmdir "$dir" 2>/dev/null; then
+                break
+            fi
             dir=$(dirname "$dir")
         done
         rmdir "$mount_base" 2>/dev/null || true


### PR DESCRIPTION
## What

Found by running the committed failure-injection harness end-to-end
(`dev/failure-injection/verify_nonroot.sh`): after a repo failure on the nonroot
path, an empty `/tmp/resticlvm-<ts>` dir (and its intermediate `…/mnt`) was left
behind. No resource leak — the snapshot and mounts were already released — just
untidy `/tmp` cruft that would accumulate on every failed nonroot backup.

## Cause

With #46, a single failed repo no longer aborts the job, so the script reaches
the happy-path `clean_up_snapshot`, which `rmdir`s only the **leaf** mount point.
The EXIT trap's `cleanup_snapshot_resources` rmdir-loop then started at that leaf,
found it **already gone**, and `rmdir "$dir" || break` broke immediately —
leaving the intermediate dirs and the temp base. The nonroot path uses a **nested**
mount point (`/tmp/resticlvm-<ts>/mnt/<x>`), so it had parents to leak; the root
path (single-level mount point) was unaffected, which is why the harness caught it
only on the nonroot path.

## Fix

Break only when the dir still **exists and is non-empty**; if it's already gone,
keep climbing to remove the now-empty parents and the base.

## Verification

`dev/failure-injection/verify_nonroot.sh` now passes 3/3 (was 1/3 — the
wrong-password and SIGKILL scenarios each left a temp dir). Root (5/5) and
multi-repo (2/2) harnesses unaffected. Fixes a bug in the **unreleased** #24
cleanup code, so no CHANGELOG entry — 0.8.0 simply ships the cleanup correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)