### PR TITLE
docs: document symlink step in deployment model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,10 @@ layer (`src/resticlvm/orchestration`) drives focused Bash scripts
 ## Deployment model
 
 - Install resticlvm in a dedicated venv (e.g. `/opt/resticlvm`), not pixi/conda.
-  Invoke `sudo /opt/resticlvm/bin/rlvm ...`.
+  Symlink the entrypoint onto the system PATH:
+  `sudo ln -sf /opt/resticlvm/bin/rlvm /usr/local/bin/rlvm`.
+  Example docs (`docs/EXAMPLE_SSH_SETUP.md`, `docs/EXAMPLE_B2_SETUP.md`,
+  `tools/b2/README.md`) assume this symlink is in place.
 - `restic` must be the **system** apt binary — it needs to be inside the root
   snapshot chroot for `lv_root` backups.
 - Per-host config lives in `test/test-configs-private/<host>-backup.toml`


### PR DESCRIPTION
## Summary
- Adds the `ln -sf` symlink step to CLAUDE.md's deployment model section so new installs create `/usr/local/bin/rlvm`.
- Notes that the example docs (`EXAMPLE_SSH_SETUP.md`, `EXAMPLE_B2_SETUP.md`, `tools/b2/README.md`) assume this symlink is in place.

## Test plan
- [ ] Verify the CLAUDE.md edit reads clearly and matches the actual install procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)