### PR TITLE
feat(orchestration): add SnapshotCoordinator for batch snapshot management (#84)

### DIFF
--- a/src/resticlvm/orchestration/snapshot_coordinator.py
+++ b/src/resticlvm/orchestration/snapshot_coordinator.py
@@ -1,0 +1,294 @@
+"""Batch LVM snapshot coordinator for cross-LV atomicity (issue #84).
+
+Creates all LVM snapshots before any backup runs, reducing the cross-LV
+time delta from minutes to milliseconds. Manages the full lifecycle:
+pre-flight VG space check, batch creation, COW usage reporting, and
+idempotent teardown.
+"""
+
+import atexit
+import importlib.resources as pkg_resources
+import re
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+
+from resticlvm import scripts
+from resticlvm.orchestration.data_classes import BackupJob
+
+
+@dataclass
+class SnapshotInfo:
+    """Metadata for a single active LVM snapshot."""
+
+    volume_name: str
+    vg_name: str
+    snap_name: str
+    mount_point: str
+    mount_base: str
+    snapshot_size: str
+
+
+_SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([KMGTP]?)(?:i?B)?$", re.IGNORECASE)
+_MULTIPLIERS = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4, "P": 1024**5}
+
+
+def _parse_size_bytes(size_str: str) -> int:
+    m = _SIZE_RE.match(size_str.strip())
+    if not m:
+        raise ValueError(f"Cannot parse size: {size_str!r}")
+    return int(float(m.group(1)) * _MULTIPLIERS[m.group(2).upper()])
+
+
+class SnapshotCoordinator:
+    """Manages batch snapshot creation and teardown for cross-LV atomicity.
+
+    Use as a context manager to guarantee teardown:
+
+        with SnapshotCoordinator(lv_jobs) as coord:
+            coord.create_all()
+            for job in all_jobs:
+                mount = coord.get_mount_point(job.name) if coord.has(job.name) else None
+                job.run(snapshot_mount=mount)
+        # teardown_all() runs automatically on exit
+    """
+
+    def __init__(
+        self,
+        lv_jobs: list[BackupJob],
+        dry_run: bool = False,
+        min_vg_free_after_snapshots: str = "1G",
+        snapshot_cow_warn_percent: int = 70,
+    ):
+        self._lv_jobs = lv_jobs
+        self._dry_run = dry_run
+        self._min_free = min_vg_free_after_snapshots
+        self._cow_warn_pct = snapshot_cow_warn_percent
+        self._snapshots: dict[str, SnapshotInfo] = {}
+        self._timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self._original_sigint = None
+        self._original_sigterm = None
+        self._torn_down = False
+
+    def __enter__(self):
+        self._install_signal_handlers()
+        atexit.register(self.teardown_all)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.report_cow_usage()
+        self.teardown_all()
+        self._restore_signal_handlers()
+        atexit.unregister(self.teardown_all)
+        return False
+
+    # ─── Public API ───────────────────────────────────────────────
+
+    def create_all(self) -> None:
+        """Create and mount snapshots for all LV volumes.
+
+        Runs a pre-flight VG space check, then creates snapshots one by one.
+        If any snapshot fails to create, tears down all previously created
+        snapshots and raises.
+        """
+        self._preflight_vg_space_check()
+
+        for job in self._lv_jobs:
+            try:
+                info = self._create_one(job)
+                self._snapshots[job.name] = info
+            except Exception:
+                print(
+                    f"❌ Snapshot creation failed for {job.name} — "
+                    f"tearing down {len(self._snapshots)} previously created snapshot(s).",
+                    file=sys.stderr,
+                )
+                self.teardown_all()
+                raise
+
+    def teardown_all(self) -> None:
+        """Tear down all active snapshots. Idempotent."""
+        if self._torn_down or not self._snapshots:
+            return
+
+        names = list(reversed(self._snapshots.keys()))
+        for name in names:
+            info = self._snapshots[name]
+            self._teardown_one(info)
+
+        self._snapshots.clear()
+        self._torn_down = True
+
+    def get_mount_point(self, volume_name: str) -> str:
+        """Return the snapshot mount point for a volume."""
+        return self._snapshots[volume_name].mount_point
+
+    def has(self, volume_name: str) -> bool:
+        """True if a snapshot exists for this volume name."""
+        return volume_name in self._snapshots
+
+    def report_cow_usage(self) -> None:
+        """Query and print COW utilization for each active snapshot."""
+        if self._dry_run or not self._snapshots:
+            return
+
+        print("\n📊 Snapshot COW usage:")
+        for name, info in self._snapshots.items():
+            pct = self._query_cow_percent(info)
+            if pct is None:
+                print(f"  {name:20s} ({info.snapshot_size} allocated):  unavailable")
+                continue
+
+            alloc_bytes = _parse_size_bytes(info.snapshot_size)
+            used_bytes = int(alloc_bytes * pct / 100)
+            used_str = self._format_bytes(used_bytes)
+            print(f"  {name:20s} ({info.snapshot_size} allocated):  {pct:5.1f}%  ({used_str} used)")
+
+            if pct >= self._cow_warn_pct:
+                print(
+                    f"  ⚠️  WARNING: {name} COW usage ({pct:.1f}%) exceeds "
+                    f"{self._cow_warn_pct}% threshold — consider increasing "
+                    f"snapshot_size in your backup config."
+                )
+
+    # ─── Internal ─────────────────────────────────────────────────
+
+    def _create_one(self, job: BackupJob) -> SnapshotInfo:
+        script = str(pkg_resources.files(scripts) / "snapshot_create.sh")
+        cmd = [
+            "bash", script,
+            "-g", job.config["vg_name"],
+            "-l", job.config["lv_name"],
+            "-z", str(job.config["snapshot_size"]),
+            "-t", self._timestamp,
+        ]
+        if self._dry_run:
+            cmd.append("-n")
+
+        result = subprocess.run(
+            cmd, check=True, capture_output=True, text=True,
+        )
+
+        return self._parse_create_output(job, result.stdout)
+
+    def _parse_create_output(self, job: BackupJob, stdout: str) -> SnapshotInfo:
+        kv = {}
+        for line in stdout.strip().splitlines():
+            if "=" in line:
+                key, _, val = line.partition("=")
+                kv[key.strip()] = val.strip()
+
+        return SnapshotInfo(
+            volume_name=job.name,
+            vg_name=job.config["vg_name"],
+            snap_name=kv["SNAP_NAME"],
+            mount_point=kv["SNAPSHOT_MOUNT_POINT"],
+            mount_base=kv["MOUNT_BASE"],
+            snapshot_size=str(job.config["snapshot_size"]),
+        )
+
+    def _teardown_one(self, info: SnapshotInfo) -> None:
+        script = str(pkg_resources.files(scripts) / "snapshot_teardown.sh")
+        cmd = [
+            "bash", script,
+            "-g", info.vg_name,
+            "-s", info.snap_name,
+            "-m", info.mount_point,
+            "-b", info.mount_base,
+        ]
+        if self._dry_run:
+            cmd.append("-n")
+
+        try:
+            subprocess.run(
+                cmd, check=False, stdout=sys.stdout, stderr=sys.stderr,
+            )
+        except Exception as e:
+            print(f"⚠️  Teardown error for {info.volume_name}: {e}", file=sys.stderr)
+
+    def _preflight_vg_space_check(self) -> None:
+        if self._dry_run:
+            return
+
+        by_vg: dict[str, list[BackupJob]] = {}
+        for job in self._lv_jobs:
+            vg = job.config["vg_name"]
+            by_vg.setdefault(vg, []).append(job)
+
+        margin_bytes = _parse_size_bytes(self._min_free)
+
+        for vg_name, jobs in by_vg.items():
+            vg_free = self._query_vg_free(vg_name)
+            total_snap = sum(
+                _parse_size_bytes(str(j.config["snapshot_size"])) for j in jobs
+            )
+            required = total_snap + margin_bytes
+
+            if vg_free < required:
+                snap_str = self._format_bytes(total_snap)
+                free_str = self._format_bytes(vg_free)
+                margin_str = self._min_free
+                shortfall_str = self._format_bytes(required - vg_free)
+                raise RuntimeError(
+                    f"Insufficient free space in VG '{vg_name}' for batch snapshots.\n"
+                    f"  VG free:              {free_str}\n"
+                    f"  Total snapshot alloc:  {snap_str}\n"
+                    f"  Safety margin:         {margin_str}\n"
+                    f"  Shortfall:             {shortfall_str}\n"
+                    f"  → Free up space in the VG or reduce snapshot_size values."
+                )
+
+    def _query_vg_free(self, vg_name: str) -> int:
+        result = subprocess.run(
+            ["vgs", "--noheadings", "--nosuffix", "--units", "b",
+             "-o", "vg_free", vg_name],
+            check=True, capture_output=True, text=True,
+        )
+        return int(result.stdout.strip())
+
+    def _query_cow_percent(self, info: SnapshotInfo) -> float | None:
+        try:
+            result = subprocess.run(
+                ["lvs", "--noheadings", "--nosuffix",
+                 "-o", "snap_percent",
+                 f"/dev/{info.vg_name}/{info.snap_name}"],
+                check=True, capture_output=True, text=True,
+            )
+            val = result.stdout.strip()
+            if not val:
+                return None
+            return float(val)
+        except (subprocess.CalledProcessError, ValueError):
+            return None
+
+    def _install_signal_handlers(self) -> None:
+        self._original_sigint = signal.getsignal(signal.SIGINT)
+        self._original_sigterm = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def _restore_signal_handlers(self) -> None:
+        if self._original_sigint is not None:
+            signal.signal(signal.SIGINT, self._original_sigint)
+        if self._original_sigterm is not None:
+            signal.signal(signal.SIGTERM, self._original_sigterm)
+
+    def _signal_handler(self, signum, frame):
+        sig_name = signal.Signals(signum).name
+        print(
+            f"\n⚠️  Received {sig_name} — tearing down all snapshots…",
+            file=sys.stderr,
+        )
+        self.teardown_all()
+        self._restore_signal_handlers()
+        signal.raise_signal(signum)
+
+    @staticmethod
+    def _format_bytes(n: int) -> str:
+        for unit in ("B", "K", "M", "G", "T"):
+            if abs(n) < 1024:
+                return f"{n:.1f}{unit}" if n != int(n) else f"{n}{unit}"
+            n /= 1024
+        return f"{n:.1f}P"

--- a/test/test_snapshot_coordinator.py
+++ b/test/test_snapshot_coordinator.py
@@ -1,0 +1,560 @@
+"""Tests for the SnapshotCoordinator (batch snapshot management, issue #84)."""
+
+import signal
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from resticlvm.orchestration.data_classes import BackupJob, TokenConfigKeyPair
+from resticlvm.orchestration.snapshot_coordinator import (
+    SnapshotCoordinator,
+    SnapshotInfo,
+    _parse_size_bytes,
+)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────
+
+
+def _make_lv_job(name="root", vg="vg0", lv="lv0", snap_size="30G"):
+    return BackupJob(
+        script_name="backup_lv_root.sh",
+        script_token_config_key_pairs=[],
+        config={"vg_name": vg, "lv_name": lv, "snapshot_size": snap_size},
+        name=name,
+        category="lv_root",
+        repositories=[],
+    )
+
+
+FAKE_CREATE_OUTPUT = """\
+📸 Creating LVM snapshot...
+📂 Mounting snapshot read-only...
+SNAPSHOT_DEVICE=/dev/vg0/lv0
+SNAPSHOT_MOUNT_POINT=/tmp/resticlvm-20260717_120000/vg0_lv0_snapshot_20260717_120000
+MOUNT_BASE=/tmp/resticlvm-20260717_120000
+SNAP_NAME=vg0_lv0_snapshot_20260717_120000
+"""
+
+
+def _fake_create_output(vg, lv, ts="20260717_120000"):
+    snap = f"{vg}_{lv}_snapshot_{ts}"
+    return (
+        f"SNAPSHOT_DEVICE=/dev/{vg}/{lv}\n"
+        f"SNAPSHOT_MOUNT_POINT=/tmp/resticlvm-{ts}/{snap}\n"
+        f"MOUNT_BASE=/tmp/resticlvm-{ts}\n"
+        f"SNAP_NAME={snap}\n"
+    )
+
+
+def _mock_create_run(jobs, vg_free_bytes=None):
+    """Return a side_effect callable that returns correct output per job index.
+
+    Also handles vgs calls for the pre-flight check, returning enough free
+    space by default (100G) unless vg_free_bytes is specified.
+    """
+    if vg_free_bytes is None:
+        vg_free_bytes = 100 * 1024**3
+
+    outputs = []
+    for j in jobs:
+        outputs.append(_fake_create_output(j.config["vg_name"], j.config["lv_name"]))
+
+    call_count = [0]
+
+    def side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "vgs":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=f"  {vg_free_bytes}\n", stderr=""
+            )
+        if "snapshot_create.sh" in str(cmd[1]):
+            idx = call_count[0]
+            call_count[0] += 1
+            return subprocess.CompletedProcess(cmd, 0, stdout=outputs[idx], stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+# ─── _parse_size_bytes ────────────────────────────────────────────
+
+
+class TestParseSizeBytes:
+    def test_plain_number(self):
+        assert _parse_size_bytes("1024") == 1024
+
+    def test_gigabytes(self):
+        assert _parse_size_bytes("30G") == 30 * 1024**3
+
+    def test_megabytes(self):
+        assert _parse_size_bytes("512M") == 512 * 1024**2
+
+    def test_case_insensitive(self):
+        assert _parse_size_bytes("10g") == 10 * 1024**3
+
+    def test_with_ib_suffix(self):
+        assert _parse_size_bytes("5GiB") == 5 * 1024**3
+
+    def test_fractional(self):
+        assert _parse_size_bytes("1.5G") == int(1.5 * 1024**3)
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Cannot parse size"):
+            _parse_size_bytes("lots")
+
+
+# ─── SnapshotInfo ─────────────────────────────────────────────────
+
+
+def test_snapshot_info_fields():
+    info = SnapshotInfo(
+        volume_name="root",
+        vg_name="vg0",
+        snap_name="vg0_lv0_snap",
+        mount_point="/tmp/resticlvm-ts/vg0_lv0_snap",
+        mount_base="/tmp/resticlvm-ts",
+        snapshot_size="30G",
+    )
+    assert info.volume_name == "root"
+    assert info.vg_name == "vg0"
+
+
+# ─── Context manager ─────────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_context_manager_calls_teardown(mock_run):
+    """__exit__ calls teardown_all, cleaning up all snapshots."""
+    jobs = [_make_lv_job()]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    with SnapshotCoordinator(jobs) as coord:
+        coord.create_all()
+        assert coord.has("root")
+
+    # After exiting, teardown should have been called
+    teardown_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_teardown.sh" in str(c)
+    ]
+    assert len(teardown_calls) == 1
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_context_manager_teardown_on_exception(mock_run):
+    """Snapshots are torn down even when an exception occurs inside the block."""
+    jobs = [_make_lv_job()]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with SnapshotCoordinator(jobs) as coord:
+            coord.create_all()
+            raise RuntimeError("boom")
+
+    teardown_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_teardown.sh" in str(c)
+    ]
+    assert len(teardown_calls) == 1
+
+
+# ─── create_all ───────────────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_create_all_single_job(mock_run):
+    """create_all with one job calls snapshot_create.sh and records the result."""
+    jobs = [_make_lv_job()]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    coord.create_all()
+
+    assert coord.has("root")
+    mp = coord.get_mount_point("root")
+    assert "resticlvm-" in mp
+    assert "vg0_lv0" in mp
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_create_all_multiple_jobs(mock_run):
+    """create_all creates snapshots for all LV jobs."""
+    jobs = [
+        _make_lv_job(name="root", vg="vg0", lv="lv0", snap_size="30G"),
+        _make_lv_job(name="git", vg="vg0", lv="lv_git_01", snap_size="10G"),
+        _make_lv_job(name="mail", vg="vg0", lv="lv_mail_01", snap_size="10G"),
+    ]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    coord.create_all()
+
+    assert coord.has("root")
+    assert coord.has("git")
+    assert coord.has("mail")
+    assert "lv_git_01" in coord.get_mount_point("git")
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_create_all_passes_batch_timestamp(mock_run):
+    """All snapshot_create.sh calls receive the same -t timestamp."""
+    jobs = [
+        _make_lv_job(name="root"),
+        _make_lv_job(name="git", lv="lv_git_01"),
+    ]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    coord.create_all()
+
+    create_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_create.sh" in str(c)
+    ]
+    timestamps = set()
+    for call in create_calls:
+        cmd = call.kwargs.get("args") or call[0][0]
+        t_idx = cmd.index("-t")
+        timestamps.add(cmd[t_idx + 1])
+
+    assert len(timestamps) == 1
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_create_all_passes_dry_run(mock_run):
+    """In dry_run mode, -n is passed to snapshot_create.sh."""
+    jobs = [_make_lv_job()]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    coord.create_all()
+
+    create_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_create.sh" in str(c)
+    ]
+    cmd = create_calls[0].kwargs.get("args") or create_calls[0][0][0]
+    assert "-n" in cmd
+
+
+# ─── create_all rollback on failure ───────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_create_all_rollback_on_failure(mock_run):
+    """If snapshot #2 fails, snapshot #1 is torn down before raising."""
+    jobs = [
+        _make_lv_job(name="root", lv="lv0"),
+        _make_lv_job(name="git", lv="lv_git_01"),
+    ]
+
+    call_count = [0]
+
+    def side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if "snapshot_create.sh" in str(cmd[1]):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise subprocess.CalledProcessError(1, cmd)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_fake_create_output("vg0", "lv0"), stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = side_effect
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    with pytest.raises(subprocess.CalledProcessError):
+        coord.create_all()
+
+    teardown_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_teardown.sh" in str(c)
+    ]
+    assert len(teardown_calls) == 1
+
+
+# ─── teardown_all ─────────────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_teardown_all_idempotent(mock_run):
+    """Calling teardown_all twice does not call snapshot_teardown.sh twice."""
+    jobs = [_make_lv_job()]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    coord.create_all()
+    coord.teardown_all()
+    coord.teardown_all()
+
+    teardown_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_teardown.sh" in str(c)
+    ]
+    assert len(teardown_calls) == 1
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_teardown_all_reverse_order(mock_run):
+    """Snapshots are torn down in reverse creation order."""
+    jobs = [
+        _make_lv_job(name="root", lv="lv0"),
+        _make_lv_job(name="git", lv="lv_git_01"),
+        _make_lv_job(name="mail", lv="lv_mail_01"),
+    ]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    coord.create_all()
+    coord.teardown_all()
+
+    teardown_calls = [
+        c for c in mock_run.call_args_list
+        if "snapshot_teardown.sh" in str(c)
+    ]
+    assert len(teardown_calls) == 3
+
+    teardown_snaps = []
+    for call in teardown_calls:
+        cmd = call.kwargs.get("args") or call[0][0]
+        s_idx = cmd.index("-s")
+        teardown_snaps.append(cmd[s_idx + 1])
+
+    assert "lv_mail_01" in teardown_snaps[0]
+    assert "lv_git_01" in teardown_snaps[1]
+    assert "lv0" in teardown_snaps[2]
+
+
+# ─── get_mount_point / has ────────────────────────────────────────
+
+
+def test_get_mount_point_missing_raises():
+    coord = SnapshotCoordinator([])
+    with pytest.raises(KeyError):
+        coord.get_mount_point("nonexistent")
+
+
+def test_has_false_when_empty():
+    coord = SnapshotCoordinator([])
+    assert coord.has("root") is False
+
+
+# ─── Pre-flight VG space check ───────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_preflight_passes_with_enough_space(mock_run):
+    """Pre-flight check passes when VG has enough free space."""
+    jobs = [
+        _make_lv_job(name="root", snap_size="30G"),
+        _make_lv_job(name="git", lv="lv_git_01", snap_size="10G"),
+    ]
+
+    def side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "vgs":
+            # 50G free (30G + 10G + 1G margin = 41G needed)
+            free = str(50 * 1024**3)
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"  {free}\n", stderr="")
+        if "snapshot_create.sh" in str(cmd[1]):
+            vg = cmd[cmd.index("-g") + 1]
+            lv = cmd[cmd.index("-l") + 1]
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_fake_create_output(vg, lv), stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = side_effect
+
+    coord = SnapshotCoordinator(jobs)
+    coord.create_all()
+    assert coord.has("root")
+    assert coord.has("git")
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_preflight_fails_insufficient_space(mock_run):
+    """Pre-flight check raises when VG free space is too low."""
+    jobs = [
+        _make_lv_job(name="root", snap_size="30G"),
+        _make_lv_job(name="git", lv="lv_git_01", snap_size="10G"),
+    ]
+
+    def side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "vgs":
+            free = str(35 * 1024**3)  # 35G < 41G needed
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"  {free}\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = side_effect
+
+    coord = SnapshotCoordinator(jobs)
+    with pytest.raises(RuntimeError, match="Insufficient free space"):
+        coord.create_all()
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_preflight_groups_by_vg(mock_run):
+    """Pre-flight check validates each VG independently."""
+    jobs = [
+        _make_lv_job(name="root", vg="vg0", snap_size="30G"),
+        _make_lv_job(name="data", vg="vg1", lv="lv_data", snap_size="20G"),
+    ]
+
+    vgs_calls = []
+
+    def side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "vgs":
+            vgs_calls.append(cmd[-1])
+            free = str(50 * 1024**3)
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"  {free}\n", stderr="")
+        if "snapshot_create.sh" in str(cmd[1]):
+            vg = cmd[cmd.index("-g") + 1]
+            lv = cmd[cmd.index("-l") + 1]
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=_fake_create_output(vg, lv), stderr=""
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = side_effect
+
+    coord = SnapshotCoordinator(jobs)
+    coord.create_all()
+
+    assert sorted(vgs_calls) == ["vg0", "vg1"]
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_preflight_custom_margin(mock_run):
+    """Custom min_vg_free_after_snapshots is honored."""
+    jobs = [_make_lv_job(name="root", snap_size="30G")]
+
+    def side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "vgs":
+            free = str(35 * 1024**3)  # 35G: enough for 30G + 1G, not 30G + 10G
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"  {free}\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = side_effect
+
+    coord = SnapshotCoordinator(jobs, min_vg_free_after_snapshots="10G")
+    with pytest.raises(RuntimeError, match="Insufficient free space"):
+        coord.create_all()
+
+
+def test_preflight_skipped_in_dry_run():
+    """Dry-run mode skips the pre-flight check (no vgs call needed)."""
+    jobs = [_make_lv_job()]
+    coord = SnapshotCoordinator(jobs, dry_run=True)
+    # Would fail without mock if it actually called vgs
+    # (create_all will still call snapshot_create.sh, tested elsewhere)
+
+
+# ─── COW usage reporting ─────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_cow_report_normal(mock_run, capsys):
+    """COW usage report prints percentages for each snapshot."""
+    jobs = [_make_lv_job(name="root")]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs)
+    coord.create_all()
+
+    # Override mock for the lvs cow query
+    def cow_side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "lvs":
+            return subprocess.CompletedProcess(cmd, 0, stdout="  12.34\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = cow_side_effect
+    coord.report_cow_usage()
+
+    captured = capsys.readouterr()
+    assert "12.3%" in captured.out
+    assert "root" in captured.out
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_cow_report_warning(mock_run, capsys):
+    """COW usage above the threshold triggers a warning."""
+    jobs = [_make_lv_job(name="root")]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs, snapshot_cow_warn_percent=50)
+    coord.create_all()
+
+    def cow_side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "lvs":
+            return subprocess.CompletedProcess(cmd, 0, stdout="  75.0\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = cow_side_effect
+    coord.report_cow_usage()
+
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.out
+    assert "75.0%" in captured.out
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_cow_report_unavailable(mock_run, capsys):
+    """COW report handles unavailable snap_percent gracefully."""
+    jobs = [_make_lv_job(name="root")]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    coord = SnapshotCoordinator(jobs)
+    coord.create_all()
+
+    def cow_side_effect(*args, **kwargs):
+        cmd = kwargs.get("args") or args[0]
+        if cmd[0] == "lvs":
+            raise subprocess.CalledProcessError(5, cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    mock_run.side_effect = cow_side_effect
+    coord.report_cow_usage()
+
+    captured = capsys.readouterr()
+    assert "unavailable" in captured.out
+
+
+def test_cow_report_skipped_in_dry_run(capsys):
+    """COW report is skipped in dry-run mode."""
+    coord = SnapshotCoordinator([], dry_run=True)
+    coord.report_cow_usage()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ─── Signal handler ───────────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.snapshot_coordinator.subprocess.run")
+def test_signal_handler_installed_in_context(mock_run):
+    """Signal handlers are installed on __enter__ and restored on __exit__."""
+    jobs = [_make_lv_job()]
+    mock_run.side_effect = _mock_create_run(jobs)
+
+    original_int = signal.getsignal(signal.SIGINT)
+    original_term = signal.getsignal(signal.SIGTERM)
+
+    with SnapshotCoordinator(jobs) as coord:
+        coord.create_all()
+        # During the block, handlers should be the coordinator's
+        assert signal.getsignal(signal.SIGINT) != original_int
+        assert signal.getsignal(signal.SIGTERM) != original_term
+
+    # After exiting, original handlers should be restored
+    assert signal.getsignal(signal.SIGINT) == original_int
+    assert signal.getsignal(signal.SIGTERM) == original_term


### PR DESCRIPTION
## Summary

- New `SnapshotCoordinator` class for batch LVM snapshot lifecycle management (issue #84)
- Pre-flight VG space check with configurable safety margin, grouped by VG
- Batch snapshot creation with shared timestamp across all LV volumes
- Idempotent reverse-order teardown via `snapshot_teardown.sh`
- COW usage reporting with configurable warning threshold (default 70%)
- Context manager with SIGINT/SIGTERM signal handlers and atexit for guaranteed cleanup
- Automatic rollback on partial creation failure (snapshot #N fails → tears down #1..#N-1)

This is PR 2 of 4 for #84 (cross-LV snapshot atomicity). Builds on #85. See `docs/ISSUE_84_SNAPSHOT_ATOMICITY_PLAN.md` for the full plan.

## Test plan

- [x] All 139 tests pass (`pixi run test`) — 29 new tests for the coordinator
- [x] Tests cover: creation, multi-job batching, batch timestamp sharing, dry-run passthrough, rollback on partial failure, teardown idempotency, reverse teardown ordering, VG space check (pass/fail/multi-VG grouping/custom margin), COW reporting (normal/warning/unavailable/dry-run skip), signal handler install/restore
- [x] VM integration test: deferred to PR 3 — coordinator needs to be wired into BackupJobRunner before end-to-end testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)