### PR TITLE
feat(orchestration): wire SnapshotCoordinator into BackupJobRunner (#84)

### DIFF
--- a/dev/failure-injection/verify_batch.sh
+++ b/dev/failure-injection/verify_batch.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Batch snapshot coordination verification — issue #84. Run as root, after
+# setup_nonroot.sh (which creates vg0/lv_testdata).
+#   sudo bash verify_batch.sh "$(command -v rlvm)"
+#
+# Proves that the SnapshotCoordinator creates all LVM snapshots before any
+# backup runs, and tears them all down cleanly — including on failure.
+#
+# Env overrides (defaults suit the dev VM):
+#   VG=vg0
+#   ROOT_LV=lv_root       ROOT_REPO=/srv/backup/root-local
+#   NR_LV=lv_testdata     NR_MNT=/mnt/testdata  NR_REPO=/srv/backup/testdata-local
+#   PW=/etc/resticlvm/restic-password.txt
+set -uo pipefail
+
+RLVM="${1:-${RLVM:-}}"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/_common.sh"
+fi_require_rlvm
+
+: "${ROOT_LV:=lv_root}"
+: "${ROOT_REPO:=/srv/backup/root-local}"
+: "${NR_LV:=lv_testdata}"
+: "${NR_MNT:=/mnt/testdata}"
+: "${NR_REPO:=/srv/backup/testdata-local}"
+
+fi_clean_stale_tmp
+
+# ─── Config generation ────────────────────────────────────────────
+
+GOOD="$FI_WORKDIR/batch_good.toml"
+BADPASS="$FI_WORKDIR/batch_badpass.toml"
+WRONGPW="$FI_WORKDIR/wrong-password.txt"
+
+{
+    fi_prune_block
+    cat <<EOF
+
+[volume.root]
+volume_type = "lv_root"
+vg_name = "$VG"
+lv_name = "$ROOT_LV"
+snapshot_size = "2G"
+backup_source_path = "/"
+exclude_paths = ["/dev", "/proc", "/sys", "/tmp", "/srv/backup"]
+
+[[volume.root.repositories]]
+repo_path = "$ROOT_REPO"
+password_file = "$PW"
+prune_policy = "standard"
+
+[volume.testdata]
+volume_type = "lv_nonroot"
+vg_name = "$VG"
+lv_name = "$NR_LV"
+snapshot_size = "512M"
+backup_source_path = "$NR_MNT"
+exclude_paths = []
+
+[[volume.testdata.repositories]]
+repo_path = "$NR_REPO"
+password_file = "$PW"
+prune_policy = "standard"
+EOF
+} > "$GOOD"
+
+echo 'definitely-the-wrong-password' > "$WRONGPW"
+# Bad password on the root volume only — testdata would still succeed if it
+# ran, but the batch should still report overall failure.
+sed "s#password_file = \"$PW\"#password_file = \"$WRONGPW\"#" "$GOOD" \
+    > "$BADPASS"
+
+# ─── Helpers ──────────────────────────────────────────────────────
+
+snap_count() {
+    restic -r "$1" --password-file "$PW" snapshots --json 2>/dev/null \
+        | grep -o '"short_id"' | wc -l | tr -d ' '
+}
+
+# Check that exactly N snapshot LVs exist right now in the VG.
+count_active_snapshots() {
+    lvs --noheadings -o lv_name "$VG" 2>/dev/null | grep -c '_snapshot_'
+}
+
+# ─── Scenario 1: happy path — both volumes backed up ─────────────
+
+echo ""
+echo "━━━ Scenario 1: batch happy path (both volumes) ━━━"
+root_before=$(snap_count "$ROOT_REPO")
+nr_before=$(snap_count "$NR_REPO")
+
+"$RLVM" backup --config "$GOOD" > "$FI_WORKDIR/batch_happy.log" 2>&1
+rc=$?
+
+root_after=$(snap_count "$ROOT_REPO")
+nr_after=$(snap_count "$NR_REPO")
+root_delta=$((root_after - root_before))
+nr_delta=$((nr_after - nr_before))
+snaps=$(count_active_snapshots)
+mounts=$(mount 2>/dev/null | grep -c '/tmp/resticlvm-')
+dirs=$(find /tmp -maxdepth 1 -name 'resticlvm-*' -type d 2>/dev/null | wc -l)
+
+echo "  ── batch happy path ──"
+echo "     exit code             : $rc  ($([ "$rc" -eq 0 ] && echo 'zero OK' || echo 'NON-ZERO — unexpected'))"
+echo "     root repo new snapshot: +$root_delta  ($([ "$root_delta" -eq 1 ] && echo OK || echo WRONG))"
+echo "     testdata new snapshot : +$nr_delta  ($([ "$nr_delta" -eq 1 ] && echo OK || echo WRONG))"
+echo "     leaks (snap/mnt/dir)  : $snaps / $mounts / $dirs  ($([ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ] && echo OK || echo LEAK))"
+# Check COW usage report appeared in the log
+cow_report=$(grep -c 'Snapshot COW usage' "$FI_WORKDIR/batch_happy.log")
+echo "     COW usage report      : $([ "$cow_report" -ge 1 ] && echo 'present OK' || echo 'MISSING')"
+
+if [ "$rc" -eq 0 ] && [ "$root_delta" -eq 1 ] && [ "$nr_delta" -eq 1 ] \
+    && [ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ] \
+    && [ "$cow_report" -ge 1 ]; then
+    echo "     RESULT: PASS"; fi_pass=$((fi_pass + 1))
+else
+    echo "     RESULT: FAIL   (full log: $FI_WORKDIR/batch_happy.log)"; fi_fail=$((fi_fail + 1))
+fi
+
+# ─── Scenario 2: both volumes fail — no leaks ────────────────────
+
+echo ""
+echo "━━━ Scenario 2: batch failure (wrong password, both volumes) ━━━"
+"$RLVM" backup --config "$BADPASS" > "$FI_WORKDIR/batch_fail.log" 2>&1
+check_clean "batch failure (wrong password)" "$?"
+
+# ─── Scenario 3: SIGTERM during batch backup ─────────────────────
+# All snapshots from the batch must be cleaned up.
+
+echo ""
+echo "━━━ Scenario 3: SIGTERM during batch backup ━━━"
+"$RLVM" backup --config "$GOOD" > "$FI_WORKDIR/batch_sigterm.log" 2>&1 &
+BPID=$!
+if wait_for_restic 200; then
+    sleep 0.3
+    # Send SIGTERM to the Python rlvm process (coordinator catches it)
+    kill -TERM "$BPID" 2>/dev/null
+    sleep 0.5
+    # Kill any lingering restic to unblock
+    pkill -9 -x restic 2>/dev/null
+fi
+wait "$BPID" 2>/dev/null; check_clean "SIGTERM during batch backup" "$?"
+
+# ─── Scenario 4: SIGINT (Ctrl-C) during batch backup ─────────────
+
+echo ""
+echo "━━━ Scenario 4: SIGINT during batch backup ━━━"
+"$RLVM" backup --config "$GOOD" > "$FI_WORKDIR/batch_sigint.log" 2>&1 &
+BPID=$!
+if wait_for_restic 200; then
+    sleep 0.3
+    kill -INT "$BPID" 2>/dev/null
+    sleep 0.5
+    pkill -9 -x restic 2>/dev/null
+fi
+wait "$BPID" 2>/dev/null; check_clean "SIGINT during batch backup" "$?"
+
+# ─── Scenario 5: verify snapshots coexist ─────────────────────────
+# Start a backup, then check that BOTH snapshot LVs exist simultaneously
+# before the backup finishes.
+
+echo ""
+echo "━━━ Scenario 5: verify both snapshots exist simultaneously ━━━"
+"$RLVM" backup --config "$GOOD" > "$FI_WORKDIR/batch_coexist.log" 2>&1 &
+BPID=$!
+coexist_seen=0
+if wait_for_restic 200; then
+    # restic is running, which means Phase 2 is underway — both snapshots
+    # should already exist (they were created in Phase 1).
+    sleep 0.2
+    active=$(count_active_snapshots)
+    echo "     active snapshot LVs during backup: $active"
+    [ "$active" -ge 2 ] && coexist_seen=1
+fi
+wait "$BPID" 2>/dev/null
+rc=$?
+snaps=$(count_active_snapshots)
+mounts=$(mount 2>/dev/null | grep -c '/tmp/resticlvm-')
+dirs=$(find /tmp -maxdepth 1 -name 'resticlvm-*' -type d 2>/dev/null | wc -l)
+
+echo "  ── verify snapshots coexist ──"
+echo "     both snapshots seen   : $([ "$coexist_seen" -eq 1 ] && echo 'YES — OK' || echo 'NO — could not confirm')"
+echo "     final exit code       : $rc"
+echo "     leaks (snap/mnt/dir)  : $snaps / $mounts / $dirs  ($([ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ] && echo OK || echo LEAK))"
+
+if [ "$coexist_seen" -eq 1 ] && [ "$snaps" -eq 0 ] && [ "$mounts" -eq 0 ] && [ "$dirs" -eq 0 ]; then
+    echo "     RESULT: PASS"; fi_pass=$((fi_pass + 1))
+else
+    if [ "$coexist_seen" -eq 0 ]; then
+        echo "     RESULT: INCONCLUSIVE (timing — could not observe both snapshots; backup may have been too fast)"
+        # Don't count as fail — timing-dependent observation
+    else
+        echo "     RESULT: FAIL"; fi_fail=$((fi_fail + 1))
+    fi
+fi
+
+fi_summary "Batch snapshot coordination (#84)"

--- a/docs/FAILURE_INJECTION_TESTING.md
+++ b/docs/FAILURE_INJECTION_TESTING.md
@@ -63,6 +63,19 @@ exits non-zero, no snapshot/mount/temp dir leaks, and no "aborted" trap message
 is printed (the controlled partial-failure exit path). It creates/uses a `bad`
 repo referenced with a wrong password.
 
+Batch snapshot coordination (issue #84 — all LVM snapshots created before any
+backup runs):
+
+```bash
+sudo bash dev/failure-injection/setup_nonroot.sh    # if not already done
+sudo bash dev/failure-injection/verify_batch.sh "$(command -v rlvm)"
+```
+
+Tests a multi-volume config (root + nonroot in the same VG). Verifies the happy
+path (both volumes backed up, COW usage reported), failure cleanup (wrong
+password), signal handling (SIGTERM/SIGINT tear down all snapshots), and that
+both snapshot LVs coexist during the backup.
+
 Each verify script prints a per-scenario table and a final `N passed, M failed`
 summary (exit 0 iff all passed), and prints a control-run command using a
 generated good config so you can confirm the happy path still succeeds cleanly.
@@ -76,6 +89,11 @@ generated good config so you can confirm the happy path still succeeds cleanly.
 | restic killed mid-backup | root + nonroot | `pkill -9 -x restic` once a backup is in progress |
 | SIGTERM to the backup script | root + nonroot | `pkill -TERM -f backup_lv_*.sh`, then kill restic to unblock |
 | SIGINT (Ctrl-C emulation) | root | `pkill -INT -f backup_lv_root.sh`, then kill restic to unblock |
+| batch happy path | batch | multi-volume config (root + nonroot), both backed up, COW usage reported |
+| batch failure | batch | wrong password for both volumes — all snapshots cleaned up |
+| SIGTERM during batch | batch | `kill -TERM` the `rlvm` Python process — coordinator cleans up all snapshots |
+| SIGINT during batch | batch | `kill -INT` the `rlvm` Python process — coordinator cleans up all snapshots |
+| batch snapshots coexist | batch | observe `lvs` during backup to confirm both snapshot LVs exist simultaneously |
 
 The nonroot path additionally exercises **nested** mount-point cleanup
 (`/tmp/resticlvm-<ts>/mnt/<...>`), which the root path (single-level mount point)

--- a/src/resticlvm/orchestration/backup_config.py
+++ b/src/resticlvm/orchestration/backup_config.py
@@ -56,11 +56,20 @@ class VolumeConfig:
 
 
 @dataclass
+class SnapshotSettings:
+    """Top-level snapshot coordination settings."""
+
+    min_vg_free_after_snapshots: str = "1G"
+    snapshot_cow_warn_percent: int = 70
+
+
+@dataclass
 class BackupConfig:
     """Typed, fully-resolved backup configuration."""
 
     prune_policies: dict[str, ResticPruneKeepParams]
     volumes: dict[str, VolumeConfig]
+    snapshot_settings: SnapshotSettings = field(default_factory=SnapshotSettings)
 
 
 class BackupConfigFactory:
@@ -125,8 +134,20 @@ class BackupConfigFactory:
             )
         return volumes
 
+    def _parse_snapshot_settings(self) -> SnapshotSettings:
+        raw = self._raw.get("snapshot_settings", {})
+        return SnapshotSettings(
+            min_vg_free_after_snapshots=raw.get(
+                "min_vg_free_after_snapshots", "1G"
+            ),
+            snapshot_cow_warn_percent=int(
+                raw.get("snapshot_cow_warn_percent", 70)
+            ),
+        )
+
     def build(self) -> BackupConfig:
         return BackupConfig(
             prune_policies=self._policies,
             volumes=self._parse_volumes(),
+            snapshot_settings=self._parse_snapshot_settings(),
         )

--- a/src/resticlvm/orchestration/backup_plan.py
+++ b/src/resticlvm/orchestration/backup_plan.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from resticlvm.orchestration.backup_config import (
     BackupConfigFactory,
     RepoConfig,
+    SnapshotSettings,
     VolumeConfig,
     VolumeType,
 )
@@ -82,3 +83,7 @@ class BackupPlan:
             self._build_backup_job(name, cfg)
             for name, cfg in self._config.volumes.items()
         ]
+
+    @property
+    def snapshot_settings(self) -> SnapshotSettings:
+        return self._config.snapshot_settings

--- a/src/resticlvm/orchestration/backup_runner.py
+++ b/src/resticlvm/orchestration/backup_runner.py
@@ -11,47 +11,90 @@ from pathlib import Path
 from typing import Optional
 
 from resticlvm import __version__
+from resticlvm.orchestration.backup_config import SnapshotSettings
 from resticlvm.orchestration.backup_plan import BackupPlan
 from resticlvm.orchestration.data_classes import BackupJob
 from resticlvm.orchestration.privileges import ensure_running_as_root
+from resticlvm.orchestration.snapshot_coordinator import SnapshotCoordinator
+
+_LV_CATEGORIES = {"lv_root", "lv_nonroot"}
 
 
 class BackupJobRunner:
     """Manages and runs a list of backup jobs."""
 
-    def __init__(self, jobs: list[BackupJob]):
-        """Initialize the BackupJobRunner.
-
-        Args:
-            jobs (list[BackupJob]): List of BackupJob instances to manage.
-        """
+    def __init__(
+        self,
+        jobs: list[BackupJob],
+        snapshot_settings: SnapshotSettings | None = None,
+    ):
         self.jobs = jobs
+        self._snap_settings = snapshot_settings or SnapshotSettings()
 
     def run_all(
         self, category: Optional[str] = None, name: Optional[str] = None
     ) -> int:
         """Run all backup jobs, optionally filtering by category and/or job name.
 
+        LV-backed volumes use batch snapshot coordination (issue #84): all
+        snapshots are created before any backup runs, reducing the cross-LV
+        time delta to milliseconds. Copy operations for LV jobs are deferred
+        until after snapshot teardown to minimize snapshot lifetime.
+
         Each job runs in isolation: a failure in one does not stop the others. A
         summary is printed at the end naming any failed jobs and copy operations.
 
-        Args:
-            category (str, optional): Backup category to filter by (e.g., 'standard_path').
-            name (str, optional): Specific backup job name to run.
-
         Returns:
-            int: The number of jobs that failed (a failed backup script or any
-            failed copy operation counts as a failed job). 0 means everything
-            succeeded.
+            int: The number of jobs that failed.
         """
+        active_jobs = [
+            j for j in self.jobs
+            if (not category or j.category == category)
+            and (not name or j.name == name)
+        ]
+
+        lv_jobs = [j for j in active_jobs if j.category in _LV_CATEGORIES]
+        non_lv_jobs = [j for j in active_jobs if j.category not in _LV_CATEGORIES]
+
         results = []
-        for job in self.jobs:
-            if category and job.category != category:
-                continue
-            if name and job.name != name:
-                continue
+        deferred_copy_jobs = []
+
+        if lv_jobs:
+            dry_run = lv_jobs[0].dry_run
+            coord = SnapshotCoordinator(
+                lv_jobs,
+                dry_run=dry_run,
+                min_vg_free_after_snapshots=self._snap_settings.min_vg_free_after_snapshots,
+                snapshot_cow_warn_percent=self._snap_settings.snapshot_cow_warn_percent,
+            )
+
+            with coord:
+                coord.create_all()
+
+                for job in lv_jobs:
+                    mount = coord.get_mount_point(job.name)
+                    result = job.run(snapshot_mount=mount, defer_copies=True)
+                    results.append(result)
+                    if result.script_ok:
+                        deferred_copy_jobs.append(job)
+
+            # Snapshots are now torn down — run deferred copies
+            for job in deferred_copy_jobs:
+                failed = job.run_deferred_copies()
+                if failed:
+                    for r in results:
+                        if r.name == job.name and r.category == job.category:
+                            r.failed_copies = failed
+                            break
+
+        for job in non_lv_jobs:
             results.append(job.run())
 
+        self._print_summary(results)
+        return len([r for r in results if not r.ok])
+
+    @staticmethod
+    def _print_summary(results):
         failures = [r for r in results if not r.ok]
         total = len(results)
         print()
@@ -70,8 +113,6 @@ class BackupJobRunner:
             print("──────── Backup run summary ────────")
             print(f"  ✅ All {total} job(s) completed successfully.")
 
-        return len(failures)
-
 
 def run(args):
     """Execute the backup plan from pre-parsed arguments.
@@ -82,7 +123,10 @@ def run(args):
     config_path = Path(args.config)
 
     plan = BackupPlan(config_path=config_path, dry_run=args.dry_run)
-    runner = BackupJobRunner(plan.backup_jobs)
+    runner = BackupJobRunner(
+        plan.backup_jobs,
+        snapshot_settings=plan.snapshot_settings,
+    )
     failure_count = runner.run_all(category=args.category, name=args.name)
     if failure_count:
         sys.exit(1)

--- a/src/resticlvm/orchestration/data_classes.py
+++ b/src/resticlvm/orchestration/data_classes.py
@@ -146,7 +146,11 @@ class BackupJob:
                     return True
         return False
 
-    def run(self, snapshot_mount: str | None = None) -> "JobResult":
+    def run(
+        self,
+        snapshot_mount: str | None = None,
+        defer_copies: bool = False,
+    ) -> "JobResult":
         """Execute the backup job by running the associated script.
 
         Failures are caught (not raised) so that one failed job does not abort the
@@ -157,6 +161,9 @@ class BackupJob:
             snapshot_mount: When set, pass --snapshot-mount to the shell script
                 so it uses a pre-mounted snapshot instead of managing its own
                 (batch mode, issue #84).
+            defer_copies: When True, skip copy operations after backup. The
+                caller is responsible for calling run_deferred_copies() later
+                (used in batch mode to free snapshots before copying).
 
         Returns:
             JobResult: The outcome of this job — whether the backup script
@@ -204,7 +211,14 @@ class BackupJob:
                 )
             print(f"✅ Backup [{self.category}.{self.name}] completed.\n")
 
-            # After successful backup, copy to remote destinations
+            if defer_copies:
+                return JobResult(
+                    category=self.category,
+                    name=self.name,
+                    script_ok=True,
+                    failed_copies=[],
+                )
+
             failed_copies = self._run_copy_operations(env)
             return JobResult(
                 category=self.category,
@@ -224,6 +238,28 @@ class BackupJob:
             script_ok=False,
             failed_copies=[],
         )
+
+    def run_deferred_copies(self) -> list:
+        """Run copy operations that were deferred during run(defer_copies=True).
+
+        Returns:
+            list: Copy-destination repo_paths that failed (empty if all succeeded).
+        """
+        env = os.environ.copy()
+        env.setdefault("SSH_AUTH_SOCK", "/root/.ssh/ssh-agent.sock")
+
+        if self._uses_b2():
+            try:
+                load_b2_credentials(env)
+            except B2CredentialsError as e:
+                print(f"❌ B2 credentials for copies [{self.category}.{self.name}]: {e}")
+                return [
+                    d.repo_path
+                    for r in self.repositories
+                    for d in (r.copy_destinations or [])
+                ]
+
+        return self._run_copy_operations(env)
 
     def _run_copy_operations(self, env: dict) -> list:
         """Execute copy operations for repositories with copy_to destinations.

--- a/test/test_backup_config.py
+++ b/test/test_backup_config.py
@@ -7,6 +7,7 @@ from resticlvm.orchestration.backup_config import (
     BackupConfigFactory,
     CopyDestConfig,
     RepoConfig,
+    SnapshotSettings,
     VolumeConfig,
     VolumeType,
 )
@@ -306,3 +307,34 @@ def test_exclude_paths_defaults_to_empty():
     }
     cfg = BackupConfigFactory(raw).build()
     assert cfg.volumes["boot"].exclude_paths == []
+
+
+# ─── Snapshot settings (issue #84) ────────────────────────────────
+
+
+def test_snapshot_settings_defaults():
+    """Snapshot settings use defaults when not specified in config."""
+    cfg = BackupConfigFactory(_minimal_config()).build()
+    assert cfg.snapshot_settings.min_vg_free_after_snapshots == "1G"
+    assert cfg.snapshot_settings.snapshot_cow_warn_percent == 70
+
+
+def test_snapshot_settings_custom():
+    """Custom snapshot settings are parsed from config."""
+    raw = _minimal_config()
+    raw["snapshot_settings"] = {
+        "min_vg_free_after_snapshots": "5G",
+        "snapshot_cow_warn_percent": 80,
+    }
+    cfg = BackupConfigFactory(raw).build()
+    assert cfg.snapshot_settings.min_vg_free_after_snapshots == "5G"
+    assert cfg.snapshot_settings.snapshot_cow_warn_percent == 80
+
+
+def test_snapshot_settings_partial():
+    """Only specified snapshot settings override defaults."""
+    raw = _minimal_config()
+    raw["snapshot_settings"] = {"snapshot_cow_warn_percent": 50}
+    cfg = BackupConfigFactory(raw).build()
+    assert cfg.snapshot_settings.min_vg_free_after_snapshots == "1G"
+    assert cfg.snapshot_settings.snapshot_cow_warn_percent == 50

--- a/test/test_backup_runner.py
+++ b/test/test_backup_runner.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from resticlvm.orchestration import backup_runner
+from resticlvm.orchestration.backup_config import SnapshotSettings
 from resticlvm.orchestration.backup_runner import BackupJobRunner
 from resticlvm.orchestration.data_classes import JobResult
 
@@ -15,6 +16,18 @@ def _fake_job(category, name, result):
     job.category = category
     job.name = name
     job.run.return_value = result
+    return job
+
+
+def _fake_lv_job(name, result, dry_run=False):
+    """A stand-in LV BackupJob with config dict for the coordinator."""
+    job = mock.Mock()
+    job.category = "lv_root"
+    job.name = name
+    job.dry_run = dry_run
+    job.config = {"vg_name": "vg0", "lv_name": f"lv_{name}", "snapshot_size": "10G"}
+    job.run.return_value = result
+    job.run_deferred_copies.return_value = []
     return job
 
 
@@ -130,3 +143,157 @@ def test_run_exits_nonzero_on_failure(monkeypatch):
 def test_run_exits_zero_on_success(monkeypatch):
     """run() returns normally (no SystemExit) when nothing failed."""
     _run_with_failure_count(monkeypatch, failure_count=0)
+
+
+# ─── Batch snapshot coordination (issue #84) ──────────────────────
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_lv_jobs_use_coordinator(MockCoord):
+    """LV jobs are run through the SnapshotCoordinator."""
+    coord = MockCoord.return_value
+    coord.__enter__ = mock.Mock(return_value=coord)
+    coord.__exit__ = mock.Mock(return_value=False)
+    coord.get_mount_point.return_value = "/tmp/resticlvm/snap"
+
+    job = _fake_lv_job(
+        "root",
+        JobResult("lv_root", "root", script_ok=True, failed_copies=[]),
+    )
+
+    runner = BackupJobRunner([job])
+    runner.run_all()
+
+    MockCoord.assert_called_once()
+    coord.create_all.assert_called_once()
+    job.run.assert_called_once_with(
+        snapshot_mount="/tmp/resticlvm/snap", defer_copies=True,
+    )
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_non_lv_jobs_skip_coordinator(MockCoord):
+    """Standard-path jobs do not go through the coordinator."""
+    job = _fake_job(
+        "standard_path", "boot",
+        JobResult("standard_path", "boot", script_ok=True, failed_copies=[]),
+    )
+
+    runner = BackupJobRunner([job])
+    runner.run_all()
+
+    MockCoord.assert_not_called()
+    job.run.assert_called_once()
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_mixed_lv_and_non_lv_jobs(MockCoord):
+    """Both LV and non-LV jobs run, LV through coordinator, non-LV directly."""
+    coord = MockCoord.return_value
+    coord.__enter__ = mock.Mock(return_value=coord)
+    coord.__exit__ = mock.Mock(return_value=False)
+    coord.get_mount_point.return_value = "/tmp/snap"
+
+    lv_job = _fake_lv_job(
+        "root",
+        JobResult("lv_root", "root", script_ok=True, failed_copies=[]),
+    )
+    path_job = _fake_job(
+        "standard_path", "boot",
+        JobResult("standard_path", "boot", script_ok=True, failed_copies=[]),
+    )
+
+    runner = BackupJobRunner([lv_job, path_job])
+    result = runner.run_all()
+
+    assert result == 0
+    lv_job.run.assert_called_once_with(
+        snapshot_mount="/tmp/snap", defer_copies=True,
+    )
+    path_job.run.assert_called_once()
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_deferred_copies_run_after_teardown(MockCoord):
+    """Copy operations for LV jobs run after the coordinator context exits."""
+    coord = MockCoord.return_value
+    coord.__enter__ = mock.Mock(return_value=coord)
+    coord.__exit__ = mock.Mock(return_value=False)
+    coord.get_mount_point.return_value = "/tmp/snap"
+
+    job = _fake_lv_job(
+        "root",
+        JobResult("lv_root", "root", script_ok=True, failed_copies=[]),
+    )
+
+    runner = BackupJobRunner([job])
+    runner.run_all()
+
+    job.run_deferred_copies.assert_called_once()
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_failed_lv_job_skips_deferred_copies(MockCoord):
+    """Copy operations are not run for LV jobs whose backup failed."""
+    coord = MockCoord.return_value
+    coord.__enter__ = mock.Mock(return_value=coord)
+    coord.__exit__ = mock.Mock(return_value=False)
+    coord.get_mount_point.return_value = "/tmp/snap"
+
+    job = _fake_lv_job(
+        "root",
+        JobResult("lv_root", "root", script_ok=False, failed_copies=[]),
+    )
+
+    runner = BackupJobRunner([job])
+    runner.run_all()
+
+    job.run_deferred_copies.assert_not_called()
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_deferred_copy_failure_counted(MockCoord, capsys):
+    """A deferred copy failure is reflected in the final failure count."""
+    coord = MockCoord.return_value
+    coord.__enter__ = mock.Mock(return_value=coord)
+    coord.__exit__ = mock.Mock(return_value=False)
+    coord.get_mount_point.return_value = "/tmp/snap"
+
+    job = _fake_lv_job(
+        "root",
+        JobResult("lv_root", "root", script_ok=True, failed_copies=[]),
+    )
+    job.run_deferred_copies.return_value = ["/srv/backup/remote"]
+
+    runner = BackupJobRunner([job])
+    result = runner.run_all()
+
+    assert result == 1
+    out = capsys.readouterr().out
+    assert "BACKUP FAILED" in out
+    assert "/srv/backup/remote" in out
+
+
+@mock.patch("resticlvm.orchestration.backup_runner.SnapshotCoordinator")
+def test_snapshot_settings_passed_to_coordinator(MockCoord):
+    """Custom snapshot settings are forwarded to the coordinator."""
+    coord = MockCoord.return_value
+    coord.__enter__ = mock.Mock(return_value=coord)
+    coord.__exit__ = mock.Mock(return_value=False)
+    coord.get_mount_point.return_value = "/tmp/snap"
+
+    job = _fake_lv_job(
+        "root",
+        JobResult("lv_root", "root", script_ok=True, failed_copies=[]),
+    )
+    settings = SnapshotSettings(
+        min_vg_free_after_snapshots="5G",
+        snapshot_cow_warn_percent=80,
+    )
+
+    runner = BackupJobRunner([job], snapshot_settings=settings)
+    runner.run_all()
+
+    call_kwargs = MockCoord.call_args.kwargs
+    assert call_kwargs["min_vg_free_after_snapshots"] == "5G"
+    assert call_kwargs["snapshot_cow_warn_percent"] == 80

--- a/test/test_data_classes.py
+++ b/test/test_data_classes.py
@@ -308,6 +308,52 @@ def test_run_script_missing(mock_run):
 
 
 @mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_defer_copies_skips_copy(mock_run):
+    """With defer_copies=True, copy operations are not run inline."""
+    copy_dest = CopyDestination(
+        repo_path="/srv/backup/remote",
+        password_file=Path("/tmp/remote_pw.txt"),
+        prune_keep_params=_make_prune_params(),
+    )
+    repo = ResticRepo(
+        repo_path=Path("/srv/backup/local"),
+        password_file=Path("/tmp/pw.txt"),
+        prune_keep_params=_make_prune_params(),
+        copy_destinations=[copy_dest],
+    )
+
+    result = _make_job(repositories=[repo]).run(defer_copies=True)
+
+    assert result.script_ok is True
+    assert result.failed_copies == []
+    assert mock_run.call_count == 1  # only the backup script, no copy
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
+def test_run_deferred_copies(mock_run):
+    """run_deferred_copies() executes copy operations separately."""
+    copy_dest = CopyDestination(
+        repo_path="/srv/backup/remote",
+        password_file=Path("/tmp/remote_pw.txt"),
+        prune_keep_params=_make_prune_params(),
+    )
+    repo = ResticRepo(
+        repo_path=Path("/srv/backup/local"),
+        password_file=Path("/tmp/pw.txt"),
+        prune_keep_params=_make_prune_params(),
+        copy_destinations=[copy_dest],
+    )
+
+    job = _make_job(repositories=[repo])
+    failed = job.run_deferred_copies()
+
+    assert failed == []
+    assert mock_run.call_count == 1  # copy script only
+    cmd = mock_run.call_args.kwargs.get("args") or mock_run.call_args[0][0]
+    assert "copy_repo.sh" in str(cmd[1])
+
+
+@mock.patch("resticlvm.orchestration.data_classes.subprocess.run")
 def test_run_copy_failure(mock_run):
     """Backup succeeds but a copy fails: script_ok True, copy recorded, not ok."""
     copy_dest = CopyDestination(


### PR DESCRIPTION
## Summary

- `BackupJobRunner.run_all()` now uses `SnapshotCoordinator` for all LV-backed volumes — snapshots are created atomically before any backup runs
- Copy operations for LV jobs are deferred until after snapshot teardown, freeing COW space sooner
- Non-LV jobs (`standard_path`) run unchanged
- New optional config settings: `snapshot_settings.min_vg_free_after_snapshots` (default `"1G"`) and `snapshot_settings.snapshot_cow_warn_percent` (default `70`)
- `BackupJob.run()` gains `defer_copies` parameter; new `run_deferred_copies()` method for post-teardown copy execution

This is PR 3 of 4 for #84 (cross-LV snapshot atomicity). Builds on #85 and #86. See `docs/ISSUE_84_SNAPSHOT_ATOMICITY_PLAN.md`.

## Test plan

- [x] All 151 tests pass (`pixi run test`) — 12 new tests
- [x] Tests cover: LV jobs routed through coordinator, non-LV jobs skip coordinator, mixed job handling, deferred copies run after teardown, failed jobs skip copies, deferred copy failures counted, snapshot settings forwarded, config parsing (defaults/custom/partial), defer_copies flag behavior, run_deferred_copies execution
- [x] VM integration test: full end-to-end with multi-LV config on `debian13-vm` — verifies all snapshots exist simultaneously and are cleaned up properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)