### PR TITLE
docs: update CLAUDE.md for #84 completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,15 @@ layer (`src/resticlvm/orchestration`) drives focused Bash scripts
   - **#81 (lv_nonroot parent detection + snapshot paths) — done.** Stable mount
     base (`/tmp/resticlvm`) + mount namespace (`unshare --mount`) so restic
     records real source paths and finds parent snapshots for incremental backups.
+  - **#84 (cross-LV snapshot atomicity) — done.** All LVM snapshots are created
+    before any backup runs, reducing cross-LV time delta to milliseconds.
+    `SnapshotCoordinator` manages batch lifecycle with pre-flight VG space check,
+    COW usage reporting, and signal-safe cleanup. Copy operations deferred until
+    after snapshot teardown. Optional config: `[snapshot_settings]` in backup TOML.
 - **Failure-injection harness:** `dev/failure-injection/` (runbook:
   `docs/FAILURE_INJECTION_TESTING.md`). Run in the `debian13-vm` VM — see
-  `docs/FRASER_VM_READY.md`.
+  `docs/FRASER_VM_READY.md`. Includes batch snapshot coordination tests
+  (`verify_batch.sh`).
 - **Remaining open:** eval/space-in-path fragility in shell scripts (deferred,
   see `docs/PRODUCTION_READINESS_REVIEW.md`).
 


### PR DESCRIPTION
## Summary

- Update CLAUDE.md status section to document #84 (cross-LV snapshot atomicity) as done
- Note the `SnapshotCoordinator`, batch lifecycle, pre-flight VG space check, COW reporting, and optional `[snapshot_settings]` config
- Reference `verify_batch.sh` in the failure-injection harness entry

Final PR (4 of 4) for #84. Closes #84.

## Test plan

- [x] Docs-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)