### PR TITLE
fix: load B2 credentials for S3 repos during prune

### DIFF
--- a/src/resticlvm/orchestration/restic_repo.py
+++ b/src/resticlvm/orchestration/restic_repo.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from resticlvm import scripts
+from resticlvm.orchestration.credentials import (
+    B2CredentialsError,
+    load_b2_credentials,
+    repo_uses_b2,
+)
 from resticlvm.orchestration.terminal import preserved_terminal
 
 
@@ -77,9 +82,15 @@ class ResticRepo:
 
         print(f"▶️ Pruning repo {self.repo_path} (dry-run={dry_run})")
 
-        # Prepare environment with SSH agent socket for SFTP repositories
         env = os.environ.copy()
-        env['SSH_AUTH_SOCK'] = '/root/.ssh/ssh-agent.sock'
+        env.setdefault('SSH_AUTH_SOCK', '/root/.ssh/ssh-agent.sock')
+
+        if repo_uses_b2(self.repo_path):
+            try:
+                load_b2_credentials(env)
+            except B2CredentialsError as e:
+                print(f"❌ B2 credentials for {self.repo_path}: {e}")
+                return
 
         try:
             # Pruning a remote repo runs ssh; guard the terminal (issue #57).

--- a/test/test_restic_repo.py
+++ b/test/test_restic_repo.py
@@ -1,6 +1,7 @@
 """Tests for the restic_repo module."""
 
 from pathlib import Path
+from unittest import mock
 
 from resticlvm.orchestration.restic_repo import (
     ResticPruneKeepParams,
@@ -33,3 +34,74 @@ def test_restic_repo_creation():
     assert repo.repo_path == Path("/srv/backup/test")
     assert repo.password_file == Path("/tmp/password.txt")
     assert repo.prune_keep_params == prune_params
+
+
+def _make_prune_params():
+    return ResticPruneKeepParams(last=5, daily=7, weekly=4, monthly=6, yearly=1)
+
+
+def _b2_repo():
+    return ResticRepo(
+        repo_path=Path("s3:s3.us-west-004.backblazeb2.com/bucket/path"),
+        password_file=Path("/tmp/pw.txt"),
+        prune_keep_params=_make_prune_params(),
+    )
+
+
+def _local_repo():
+    return ResticRepo(
+        repo_path=Path("/media/backups/local"),
+        password_file=Path("/tmp/pw.txt"),
+        prune_keep_params=_make_prune_params(),
+    )
+
+
+# ─── Prune B2 credential loading ──────────────────────────────────────────
+
+
+@mock.patch("resticlvm.orchestration.restic_repo.subprocess.run")
+def test_prune_b2_repo_without_credentials_skips(mock_run, monkeypatch):
+    """A B2 prune with no creds prints an error and never invokes restic."""
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("RESTICLVM_B2_ENV", "/nonexistent/b2-env")
+
+    _b2_repo().prune()
+
+    mock_run.assert_not_called()
+
+
+@mock.patch("resticlvm.orchestration.restic_repo.subprocess.run")
+def test_prune_b2_repo_loads_credentials_into_env(mock_run, monkeypatch):
+    """B2 creds available in the environment are threaded to the subprocess."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "id")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    _b2_repo().prune()
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["AWS_ACCESS_KEY_ID"] == "id"
+    assert env["AWS_SECRET_ACCESS_KEY"] == "secret"
+
+
+@mock.patch("resticlvm.orchestration.restic_repo.subprocess.run")
+def test_prune_local_repo_no_b2_credentials_needed(mock_run, monkeypatch):
+    """A local repo prune succeeds without any B2 credentials."""
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("RESTICLVM_B2_ENV", "/nonexistent/b2-env")
+
+    _local_repo().prune()
+
+    mock_run.assert_called_once()
+
+
+@mock.patch("resticlvm.orchestration.restic_repo.subprocess.run")
+def test_prune_respects_existing_ssh_auth_sock(mock_run, monkeypatch):
+    """SSH_AUTH_SOCK already set by the caller is not overwritten."""
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/custom/agent.sock")
+
+    _local_repo().prune()
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["SSH_AUTH_SOCK"] == "/custom/agent.sock"


### PR DESCRIPTION
## Summary
- `ResticRepo.prune()` was not loading `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for `s3:` repos, so `rlvm prune` failed on Backblaze B2 targets while `rlvm backup` worked fine.
- Added the same credential-loading flow (`repo_uses_b2` check → `load_b2_credentials`) already used by `BackupJob.run()`.
- Fixed `SSH_AUTH_SOCK` to use `setdefault` instead of unconditional assignment, matching the backup path's behavior.

Closes #93

## Test plan
- [x] New test: B2 prune without credentials skips the subprocess call
- [x] New test: B2 prune with credentials threads them into the subprocess env
- [x] New test: local repo prune succeeds without B2 credentials
- [x] New test: existing `SSH_AUTH_SOCK` is preserved
- [x] Full test suite passes (155 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)